### PR TITLE
Don't forward arguments to make_format_args

### DIFF
--- a/include/tooling/Logger.hpp
+++ b/include/tooling/Logger.hpp
@@ -39,14 +39,14 @@ namespace {
     }
     template<typename... Ts> static void log(LogType l, string_view fmt, Ts&&... ts) {
 #ifdef __cpp_lib_format
-        log(l, vformat(fmt, make_format_args(forward<Ts>(ts)...)));
+        log(l, vformat(fmt, make_format_args(ts...)));
 #else
         log(l, format(fmt, std::forward<Ts>(ts)...));
 #endif
     }
     template<typename... Ts> static void log(LogType l, string_view fmt, const srcLoc& s, Ts&&... ts) {
 #if __cpp_lib_format
-        log(l, vformat(fmt, make_format_args(forward<Ts>(ts)...)), s);
+        log(l, vformat(fmt, make_format_args(ts...)), s);
 #else
         log(l, format(fmt, std::forward<Ts>(ts)...), s);
 #endif


### PR DESCRIPTION
[P2905](https://www.open-std.org/jtc1/sc22/wg21/docs/papers/2023/p2905r2.html) retroactively makes passing an rvalue to `make_format_args` ill-formed.
This fix ensures that the project continues compiling with MSVC 17.10.3 that implemented the paper.