### PR TITLE
Rename function print to displayText in order to no longer open a pri…

### DIFF
--- a/webtest/JasmineTest.cpp
+++ b/webtest/JasmineTest.cpp
@@ -71,10 +71,10 @@ int main() {
         webFront.onUIStarted([](WF::UI ui) {
             log::info("UI Started");
             ui.addScript("var addText = function(text, num) {                 \n"
-                     "  print(text + ' of ' + num);                       \n"
+                     "  displayText(text + ' of ' + num);                       \n"
                      "}                                                   \n");
-            auto print = ui.jsFunction("addText");
-            print("Hello World", 2023);
+                     auto displayText = ui.jsFunction("addText");
+                     displayText("Hello World", 2023);
         });
         openInDefaultBrowser(httpPort, specRunnerFile);
 


### PR DESCRIPTION
Running the web tests opens a print dialog in addition to the browser window. This is caused by the JavaScript function print being called in the webtest/JasmineTest.cpp file. The function has been renamed to displayText to resolve this issue.