### PR TITLE
Ensure TypeErasedFunction forwarding constructor has constraints that prevent copying / moving objects of the same type

### DIFF
--- a/include/utils/TypeErasedFunction.hpp
+++ b/include/utils/TypeErasedFunction.hpp
@@ -131,7 +131,7 @@ public:
             std::cout << "TypeErasedFunction constructor()\n";
         }
 
-    template<typename T, typename... Args, std::enable_if_t<!std::is_same_v<std::decay_t<T>, TypeErasedFunction> && sizeof...(Args) > 0, int> = 0>
+    template<typename T, typename... Args, std::enable_if_t<!std::is_same_v<std::decay_t<T>, TypeErasedFunction> && (sizeof...(Args) > 0), int> = 0>
     TypeErasedFunction(T&& t, Args&&... args)
         : function(new FunctionPointer<typename function_traits<T>::type>(std::bind(std::forward<T>(t), std::forward<Args>(args)...))),
           voidFunction(new FunctionPointer<typename function_traits<T>::void_type>(std::bind(std::forward<T>(t), std::forward<Args>(args)...))) {

--- a/include/utils/TypeErasedFunction.hpp
+++ b/include/utils/TypeErasedFunction.hpp
@@ -127,14 +127,14 @@ private:
 public:
     template<typename T, std::enable_if_t<!std::is_same_v<std::decay_t<T>, TypeErasedFunction>, int> = 0>
     TypeErasedFunction(T&& t)
-        : function(new FunctionPointer<typename function_traits<T>::type>(std::forward<T>(t))), voidFunction(new FunctionPointer<typename function_traits<T>::void_type>(std::forward<T>(t))) {
+        : function(new FunctionPointer<typename function_traits<std::decay_t<T>>::type>(std::forward<T>(t))), voidFunction(new FunctionPointer<typename function_traits<std::decay_t<T>>::void_type>(std::forward<T>(t))) {
             std::cout << "TypeErasedFunction constructor()\n";
         }
 
     template<typename T, typename... Args, std::enable_if_t<!std::is_same_v<std::decay_t<T>, TypeErasedFunction> && (sizeof...(Args) > 0), int> = 0>
     TypeErasedFunction(T&& t, Args&&... args)
-        : function(new FunctionPointer<typename function_traits<T>::type>(std::bind(std::forward<T>(t), std::forward<Args>(args)...))),
-          voidFunction(new FunctionPointer<typename function_traits<T>::void_type>(std::bind(std::forward<T>(t), std::forward<Args>(args)...))) {
+        : function(new FunctionPointer<typename function_traits<std::decay_t<T>>::type>(std::bind(std::forward<T>(t), std::forward<Args>(args)...))),
+          voidFunction(new FunctionPointer<typename function_traits<std::decay_t<T>>::void_type>(std::bind(std::forward<T>(t), std::forward<Args>(args)...))) {
         std::cout << "TypeErasedFunction constructor(";
         ((std::cout << TypeName(args)), ...);
         std::cout << ")\n";

--- a/include/utils/TypeErasedFunction.hpp
+++ b/include/utils/TypeErasedFunction.hpp
@@ -5,6 +5,7 @@
 #include <functional>
 #include <memory>
 #include <stdexcept>
+#include <type_traits>
 
 #include <array>
 #include <cstddef>
@@ -124,13 +125,13 @@ private:
     };
 
 public:
-    template<typename T>
+    template<typename T, std::enable_if_t<!std::is_same_v<std::decay_t<T>, TypeErasedFunction>, int> = 0>
     TypeErasedFunction(T t)
         : function(new FunctionPointer<typename function_traits<T>::type>(t)), voidFunction(new FunctionPointer<typename function_traits<T>::void_type>(t)) {
             std::cout << "TypeErasedFunction constructor()\n";
         }
 
-    template<typename T, typename... Args>
+    template<typename T, typename... Args, std::enable_if_t<!std::is_same_v<std::decay_t<T>, TypeErasedFunction>, int> = 0>
     TypeErasedFunction(T&& t, Args&&... args)
         : function(new FunctionPointer<typename function_traits<T>::type>(std::bind(std::forward<T>(t), std::forward<Args>(args)...))),
           voidFunction(new FunctionPointer<typename function_traits<T>::void_type>(std::bind(std::forward<T>(t), std::forward<Args>(args)...))) {

--- a/include/utils/TypeErasedFunction.hpp
+++ b/include/utils/TypeErasedFunction.hpp
@@ -126,12 +126,12 @@ private:
 
 public:
     template<typename T, std::enable_if_t<!std::is_same_v<std::decay_t<T>, TypeErasedFunction>, int> = 0>
-    TypeErasedFunction(T t)
-        : function(new FunctionPointer<typename function_traits<T>::type>(t)), voidFunction(new FunctionPointer<typename function_traits<T>::void_type>(t)) {
+    TypeErasedFunction(T&& t)
+        : function(new FunctionPointer<typename function_traits<T>::type>(std::forward<T>(t))), voidFunction(new FunctionPointer<typename function_traits<T>::void_type>(std::forward<T>(t))) {
             std::cout << "TypeErasedFunction constructor()\n";
         }
 
-    template<typename T, typename... Args, std::enable_if_t<!std::is_same_v<std::decay_t<T>, TypeErasedFunction>, int> = 0>
+    template<typename T, typename... Args, std::enable_if_t<!std::is_same_v<std::decay_t<T>, TypeErasedFunction> && sizeof...(Args) > 0, int> = 0>
     TypeErasedFunction(T&& t, Args&&... args)
         : function(new FunctionPointer<typename function_traits<T>::type>(std::bind(std::forward<T>(t), std::forward<Args>(args)...))),
           voidFunction(new FunctionPointer<typename function_traits<T>::void_type>(std::bind(std::forward<T>(t), std::forward<Args>(args)...))) {


### PR DESCRIPTION
Resolves #140

Added std::enable_if_t constraints to both templated constructors to prevent them from interfering with copy/move constructors when passed objects of the same type (TypeErasedFunction).

The constraints use std::decay_t to strip cv-qualifiers and references before checking type equality, ensuring that TypeErasedFunction&, const TypeErasedFunction&, etc. are all properly excluded from the template instantiation.

Changes:
- Added #include <type_traits>
- Added SFINAE constraint to single-parameter constructor
- Added SFINAE constraint to forwarding constructor with variadic args