### PR TITLE
Configurable buffer size policy

### DIFF
--- a/include/http/BuffersPolicy.hpp
+++ b/include/http/BuffersPolicy.hpp
@@ -1,0 +1,63 @@
+/// @file BuffersPolicy.hpp
+/// @brief Configurable buffer sizes policy for WebFront
+/// @author Ambroise Leclerc
+/// @version 1.0
+/// @date 2025-11-23
+
+#pragma once
+
+#include <cstddef>
+#include <stdexcept>
+#include <string>
+
+namespace webfront::http {
+
+/// @brief Exception thrown when a buffer overflow is detected
+class BufferOverflowException : public std::runtime_error {
+public:
+    explicit BufferOverflowException(const std::string& message)
+        : std::runtime_error(message) {}
+
+    explicit BufferOverflowException(const char* message)
+        : std::runtime_error(message) {}
+};
+
+/// @brief Concept defining requirements for a valid BuffersPolicy
+template<typename T>
+concept BuffersPolicyType = requires {
+    { T::receptionBufferSize } -> std::convertible_to<size_t>;
+    { T::emissionBufferSize } -> std::convertible_to<size_t>;
+    { T::functionCallBufferSize } -> std::convertible_to<size_t>;
+};
+
+/// @brief Default buffers policy with configurable buffer sizes
+/// @details This policy defines the default sizes for internal buffers used by WebFront:
+///          - receptionBufferSize: Size of buffers used for receiving HTTP/WebSocket data
+///          - emissionBufferSize: Size of buffers used for sending HTTP/WebSocket data
+///          - functionCallBufferSize: Size of buffers used for encoding function call parameters
+struct DefaultBuffersPolicy {
+    /// @brief Size of reception buffers (default: 8192 bytes)
+    static constexpr size_t receptionBufferSize = 8192;
+
+    /// @brief Size of emission buffers (default: 8192 bytes)
+    static constexpr size_t emissionBufferSize = 8192;
+
+    /// @brief Size of function call encoding buffers (default: 32768 bytes)
+    static constexpr size_t functionCallBufferSize = 32768;
+};
+
+/// @brief Custom buffers policy template for user-defined buffer sizes
+/// @tparam ReceptionSize Size of reception buffers in bytes
+/// @tparam EmissionSize Size of emission buffers in bytes
+/// @tparam FunctionCallSize Size of function call encoding buffers in bytes
+template<size_t ReceptionSize = 8192, size_t EmissionSize = 8192, size_t FunctionCallSize = 32768>
+struct CustomBuffersPolicy {
+    static constexpr size_t receptionBufferSize = ReceptionSize;
+    static constexpr size_t emissionBufferSize = EmissionSize;
+    static constexpr size_t functionCallBufferSize = FunctionCallSize;
+};
+
+// Ensure DefaultBuffersPolicy satisfies the concept
+static_assert(BuffersPolicyType<DefaultBuffersPolicy>, "DefaultBuffersPolicy must satisfy BuffersPolicyType concept");
+
+} // namespace webfront::http

--- a/include/http/HTTPServer.hpp
+++ b/include/http/HTTPServer.hpp
@@ -5,6 +5,7 @@
 #include "../networking/BasicNetworking.hpp"
 #include "../tooling/HexDump.hpp"
 #include "../system/FileSystem.hpp"
+#include "BuffersPolicy.hpp"
 #include "Encodings.hpp"
 #include "MimeType.hpp"
 #include "WebSocket.hpp"
@@ -343,8 +344,8 @@ private:
 
 enum class Protocol { HTTP, HTTPUpgrading, WebSocket };
 
-template<networking::Features Net, fs::Provider FS>
-class Connection : public std::enable_shared_from_this<Connection<Net, FS>> {
+template<networking::Features Net, fs::Provider FS, BuffersPolicyType BuffersPolicy = DefaultBuffersPolicy>
+class Connection : public std::enable_shared_from_this<Connection<Net, FS, BuffersPolicy>> {
 public:
     explicit Connection(typename Net::Socket sock, Connections<Connection>& connectionsHandler,
                         RequestHandler<Net, FS>& handler)
@@ -365,9 +366,9 @@ public:
 
 private:
     typename Net::Socket socket;
-    Connections<Connection<Net, FS>>& connections;
+    Connections<Connection<Net, FS, BuffersPolicy>>& connections;
     RequestHandler<Net, FS>& requestHandler;
-    std::array<char, 8192> buffer;
+    std::array<char, BuffersPolicy::receptionBufferSize> buffer;
     Request request;
     Response response;
     Protocol protocol = Protocol::HTTP;
@@ -419,7 +420,7 @@ private:
     }
 };
 
-template<networking::Features Net, fs::Provider FS>
+template<networking::Features Net, fs::Provider FS, BuffersPolicyType BuffersPolicy = DefaultBuffersPolicy>
 class Server {
 public:
     Server(std::string_view address, std::string_view port, std::filesystem::path docRoot = ".")
@@ -440,7 +441,7 @@ public:
 
     void run() { ioContext.run(); }
     void runOne() { ioContext.run_one(); }
-    
+
     void stop() {
         log::info("Stopping HTTP server...");
         acceptor.close();
@@ -453,14 +454,14 @@ public:
 private:
     typename Net::IoContext ioContext;
     typename Net::Acceptor acceptor;
-    Connections<Connection<Net, FS>> connections;
+    Connections<Connection<Net, FS, BuffersPolicy>> connections;
     RequestHandler<Net, FS> requestHandler;
     std::function<void(typename Net::Socket socket, Protocol protocol)> upgradeHandler;
 
     void accept() {
         acceptor.async_accept([this](std::error_code ec, typename Net::Socket socket) {
             if (!acceptor.is_open()) return;
-            auto newConnection = std::make_shared<Connection<Net, FS>>(std::move(socket), connections, requestHandler);
+            auto newConnection = std::make_shared<Connection<Net, FS, BuffersPolicy>>(std::move(socket), connections, requestHandler);
             newConnection->onUpgrade = upgradeHandler;
             if (!ec) connections.start(newConnection);
             accept();

--- a/include/http/WebSocket.hpp
+++ b/include/http/WebSocket.hpp
@@ -2,6 +2,7 @@
 /// @author Ambroise Leclerc
 /// @brief WebSocket protocol implementation - RFC6455
 #pragma once
+#include "BuffersPolicy.hpp"
 #include "Encodings.hpp"
 #include "../tooling/HexDump.hpp"
 #include "../tooling/Logger.hpp"
@@ -226,10 +227,9 @@ private:
     uint8_t maskIndex;
 };
 
-template<typename Net>
+template<typename Net, http::BuffersPolicyType BuffersPolicy = http::DefaultBuffersPolicy>
 class WebSocket {
     typename Net::Socket socket;
-    static constexpr size_t receptionBufferSize = 8192;
 
 public:
     explicit WebSocket(typename Net::Socket netSocket) : socket(std::move(netSocket)), started(false) {
@@ -261,7 +261,7 @@ public:
     void write(Frame<Net> frame) { writeData(std::move(frame)); }
 
 private:
-    std::array<std::byte, receptionBufferSize> readBuffer;
+    std::array<std::byte, BuffersPolicy::receptionBufferSize> readBuffer;
     FrameDecoder decoder;
     std::function<void(std::string_view)> textHandler;
     std::function<void(std::span<const std::byte>)> binaryHandler;

--- a/include/weblink/Messages.hpp
+++ b/include/weblink/Messages.hpp
@@ -3,6 +3,8 @@
 /// @brief Messages exchanged between webfront clients and server
 #pragma once
 
+#include "../http/BuffersPolicy.hpp"
+
 #include <array>
 #include <bit>
 #include <cstddef>
@@ -157,7 +159,8 @@ public:
 };
 
 /// Encodes a list of parameters : parameter 0 is the function name. Sent either by WebFront or by the JS Client
-class FunctionCall : public MessageBase<FunctionCall> {
+template<http::BuffersPolicyType BuffersPolicy = http::DefaultBuffersPolicy>
+class FunctionCall : public MessageBase<FunctionCall<BuffersPolicy>> {
     struct Header {
         Command command = Command::callFunction;
         uint8_t parametersCount = 0; // parameter 0 is the function name so parametersCount is always at least 1
@@ -166,9 +169,9 @@ class FunctionCall : public MessageBase<FunctionCall> {
     } head;
     static_assert(sizeof(Header) == 8, "FunctionCall header has to be 8 bytes long");
 
-    std::array<std::byte, 1024> buffer; // When composing a msg, buffer doesn't represent the payload but some bufferized data
+    std::array<std::byte, BuffersPolicy::functionCallBufferSize> buffer; // When composing a msg, buffer doesn't represent the payload but some bufferized data
     size_t encodeBufferIndex = 0;
-    friend class MessageBase<FunctionCall>;
+    friend class MessageBase<FunctionCall<BuffersPolicy>>;
 
     template<typename T>
     constexpr auto typeName() {
@@ -211,6 +214,9 @@ public:
         }
 
         [[maybe_unused]] auto encodeType = [&, this](msg::CodedType type, auto size, WebSocketFrame& wsFrame) {
+            if (encodeBufferIndex + 1 + sizeof(size) > buffer.size()) {
+                throw http::BufferOverflowException("Function call buffer overflow: insufficient space for encoding type");
+            }
             wsFrame.addBuffer(std::span(&buffer[encodeBufferIndex], 1 + sizeof(size)));
             buffer[encodeBufferIndex++] = static_cast<std::byte>(type);
             std::copy_n(reinterpret_cast<const std::byte*>(&size), sizeof(size), &buffer[encodeBufferIndex]);
@@ -235,6 +241,9 @@ public:
             std::apply([&](auto&... tupleArgs) { ((encodeParameter(tupleArgs, frame)), ...); }, t);
         }
         else if constexpr (is_same_v<ParamType, bool>) {
+            if (encodeBufferIndex + 1 > buffer.size()) {
+                throw http::BufferOverflowException("Function call buffer overflow: insufficient space for encoding boolean");
+            }
             frame.addBuffer(span(&buffer[encodeBufferIndex], 1));
             buffer[encodeBufferIndex++] = static_cast<byte>(t ? msg::CodedType::booleanTrue : msg::CodedType::booleanFalse);
             incrementPayloadSize(1);
@@ -242,6 +251,9 @@ public:
         }
         else if constexpr (is_arithmetic_v<ParamType>) {
             double number = t;
+            if (encodeBufferIndex + 1 + sizeof(number) > buffer.size()) {
+                throw http::BufferOverflowException("Function call buffer overflow: insufficient space for encoding number");
+            }
             frame.addBuffer(span(&buffer[encodeBufferIndex], 1 + sizeof(number)));
             buffer[encodeBufferIndex++] = static_cast<byte>(msg::CodedType::number);
             copy_n(reinterpret_cast<const byte*>(&number), sizeof(number), &buffer[encodeBufferIndex]);
@@ -340,7 +352,8 @@ public:
 };
 
 /// Encodes FunctionCall return values (or exceptions)
-class FunctionReturn : public FunctionCall {
+template<http::BuffersPolicyType BuffersPolicy = http::DefaultBuffersPolicy>
+class FunctionReturn : public FunctionCall<BuffersPolicy> {
     struct Header {
         Command command = Command::functionReturn;
         uint8_t parametersCount = 0;
@@ -348,7 +361,7 @@ class FunctionReturn : public FunctionCall {
         uint32_t parametersDataSize = 0;
     } head;
     static_assert(sizeof(Header) == 8, "FunctionReturn header has to be 8 bytes long");
-    friend class MessageBase<FunctionReturn>;
+    friend class MessageBase<FunctionReturn<BuffersPolicy>>;
 };
 
 } // namespace webfront::msg


### PR DESCRIPTION


This commit adds a configurable buffer size policy system with three configurable parameters and overflow exception handling:

- Created BuffersPolicy.hpp with DefaultBuffersPolicy and CustomBuffersPolicy
- Added BufferOverflowException for buffer overflow detection
- Updated HTTPServer to use configurable reception buffer sizes
- Updated WebSocket to use configurable reception buffer sizes
- Updated Messages to use configurable function call buffer sizes
- Added overflow checks in FunctionCall::encodeParameter methods

Buffer sizes (defaults as specified in issue #40):
- receptionBufferSize: 8192 bytes
- emissionBufferSize: 8192 bytes
- functionCallBufferSize: 32768 bytes

The implementation uses C++20 concepts to enforce policy requirements and provides template-based customization while maintaining backward compatibility through default template parameters.