### PR TITLE
Add configurable buffer size policy

### DIFF
--- a/cmake/CompilerWarnings.cmake
+++ b/cmake/CompilerWarnings.cmake
@@ -30,6 +30,7 @@ function(set_project_warnings project_name)
       /w14928 # illegal copy-initialization; more than one user-defined conversion has been implicitly applied
       /analyze # Enable Code Analysis
       /analyze:external- # Disable Code Analysis for external headers
+      /analyze:stacksize 65536 # Raise C6262 stack warning threshold to 64KB (policy buffers can reach 32KB)
       /permissive- # standards conformance mode for MSVC compiler.
   )
 

--- a/include/JsFunction.hpp
+++ b/include/JsFunction.hpp
@@ -33,7 +33,7 @@ private:
     std::string name;
     WebFront& webFront;
     WebLinkId webLinkId;
-    msg::FunctionCall command;
+    msg::FunctionCall<typename WebFront::BufferPolicy> command;
 };
 
 } // namespace webfront

--- a/include/WebFront.hpp
+++ b/include/WebFront.hpp
@@ -87,11 +87,12 @@ inline int ensureCEFInitialized() {
 }
 }  // namespace detail
 
-template <typename NetProvider, typename Filesystem>
+template <typename NetProvider, typename Filesystem, http::BuffersPolicyType Policy = http::DefaultBuffersPolicy>
 class BasicWF {
 public:
-    using Net = NetProvider;
-    using UI  = BasicUI<BasicWF<Net, Filesystem>>;
+    using Net          = NetProvider;
+    using BufferPolicy = Policy;
+    using UI           = BasicUI<BasicWF<Net, Filesystem, Policy>>;
 
     explicit BasicWF(std::string_view port, std::filesystem::path docRoot = ".")
         : httpServer((detail::ensureCEFInitialized(), "0.0.0.0"), port, docRoot), httpPort(port), httpDocRoot(docRoot), idsCounter(0) {
@@ -142,7 +143,7 @@ public:
         cppFunctions.try_emplace(functionName, [&function](std::span<const std::byte> data) -> void {
             std::tuple<Args...> parameters;
             auto                deserializeAndCall = [&]<std::size_t... Is>(std::tuple<Args...>& tuple, std::index_sequence<Is...>) {
-                (msg::FunctionCall::decodeParameter(std::get<Is>(tuple), data), ...);
+                (msg::FunctionCall<Policy>::decodeParameter(std::get<Is>(tuple), data), ...);
                 function(std::get<Is>(tuple)...);
             };
 
@@ -179,10 +180,10 @@ public:
     }
 
 private:
-    http::Server<Net, Filesystem>                                          httpServer;
-    std::string_view                                                       httpPort;
-    std::filesystem::path                                                  httpDocRoot;
-    std::map<WebLinkId, WebLink<Net>>                                      webLinks;
+    http::Server<Net, Filesystem, Policy>                                    httpServer;
+    std::string_view                                                         httpPort;
+    std::filesystem::path                                                    httpDocRoot;
+    std::map<WebLinkId, WebLink<Net, Policy>>                                webLinks;
     WebLinkId                                                              idsCounter{0};
     std::function<void(UI)>                                                uiStartedHandler;
     std::map<std::string, std::function<void(std::span<const std::byte>)>> cppFunctions;

--- a/include/http/BuffersPolicy.hpp
+++ b/include/http/BuffersPolicy.hpp
@@ -1,0 +1,43 @@
+/// @date 28/02/2026
+/// @author Ambroise Leclerc
+/// @brief Configurable buffer sizes policy for WebFront internal buffers
+#pragma once
+
+#include <concepts>
+#include <cstddef>
+#include <stdexcept>
+
+namespace webfront::http {
+
+/// Exception thrown when an internal buffer overflows during encoding
+class BufferOverflowException : public std::runtime_error {
+public:
+    using std::runtime_error::runtime_error;
+};
+
+/// Concept defining requirements for a valid buffers policy
+template<typename T>
+concept BuffersPolicyType = requires {
+    { T::receptionBufferSize } -> std::convertible_to<size_t>;
+    { T::emissionBufferSize } -> std::convertible_to<size_t>;
+    { T::functionCallBufferSize } -> std::convertible_to<size_t>;
+};
+
+/// Default buffer sizes as specified in issue #40
+struct DefaultBuffersPolicy {
+    static constexpr size_t receptionBufferSize    = 8192;
+    static constexpr size_t emissionBufferSize     = 8192;
+    static constexpr size_t functionCallBufferSize = 32768;
+};
+
+/// Custom policy template for user-defined buffer sizes
+template<size_t ReceptionSize = 8192, size_t EmissionSize = 8192, size_t FunctionCallSize = 32768>
+struct CustomBuffersPolicy {
+    static constexpr size_t receptionBufferSize    = ReceptionSize;
+    static constexpr size_t emissionBufferSize     = EmissionSize;
+    static constexpr size_t functionCallBufferSize = FunctionCallSize;
+};
+
+static_assert(BuffersPolicyType<DefaultBuffersPolicy>);
+
+} // namespace webfront::http

--- a/include/http/HTTPServer.hpp
+++ b/include/http/HTTPServer.hpp
@@ -5,6 +5,7 @@
 #include "../networking/BasicNetworking.hpp"
 #include "../tooling/HexDump.hpp"
 #include "../system/FileSystem.hpp"
+#include "BuffersPolicy.hpp"
 #include "Encodings.hpp"
 #include "MimeType.hpp"
 #include "WebSocket.hpp"
@@ -343,8 +344,8 @@ private:
 
 enum class Protocol { HTTP, HTTPUpgrading, WebSocket };
 
-template<networking::Features Net, fs::Provider FS>
-class Connection : public std::enable_shared_from_this<Connection<Net, FS>> {
+template<networking::Features Net, fs::Provider FS, BuffersPolicyType Policy = DefaultBuffersPolicy>
+class Connection : public std::enable_shared_from_this<Connection<Net, FS, Policy>> {
 public:
     explicit Connection(typename Net::Socket sock, Connections<Connection>& connectionsHandler,
                         RequestHandler<Net, FS>& handler)
@@ -365,9 +366,9 @@ public:
 
 private:
     typename Net::Socket socket;
-    Connections<Connection<Net, FS>>& connections;
+    Connections<Connection<Net, FS, Policy>>& connections;
     RequestHandler<Net, FS>& requestHandler;
-    std::array<char, 8192> buffer;
+    std::array<char, Policy::receptionBufferSize> buffer;
     Request request;
     Response response;
     Protocol protocol = Protocol::HTTP;
@@ -419,7 +420,7 @@ private:
     }
 };
 
-template<networking::Features Net, fs::Provider FS>
+template<networking::Features Net, fs::Provider FS, BuffersPolicyType Policy = DefaultBuffersPolicy>
 class Server {
 public:
     Server(std::string_view address, std::string_view port, std::filesystem::path docRoot = ".")
@@ -453,14 +454,14 @@ public:
 private:
     typename Net::IoContext ioContext;
     typename Net::Acceptor acceptor;
-    Connections<Connection<Net, FS>> connections;
+    Connections<Connection<Net, FS, Policy>> connections;
     RequestHandler<Net, FS> requestHandler;
     std::function<void(typename Net::Socket socket, Protocol protocol)> upgradeHandler;
 
     void accept() {
         acceptor.async_accept([this](std::error_code ec, typename Net::Socket socket) {
             if (!acceptor.is_open()) return;
-            auto newConnection = std::make_shared<Connection<Net, FS>>(std::move(socket), connections, requestHandler);
+            auto newConnection = std::make_shared<Connection<Net, FS, Policy>>(std::move(socket), connections, requestHandler);
             newConnection->onUpgrade = upgradeHandler;
             if (!ec) connections.start(newConnection);
             accept();

--- a/include/http/WebSocket.hpp
+++ b/include/http/WebSocket.hpp
@@ -2,6 +2,7 @@
 /// @author Ambroise Leclerc
 /// @brief WebSocket protocol implementation - RFC6455
 #pragma once
+#include "BuffersPolicy.hpp"
 #include "Encodings.hpp"
 #include "../tooling/HexDump.hpp"
 #include "../tooling/Logger.hpp"
@@ -226,10 +227,9 @@ private:
     uint8_t maskIndex;
 };
 
-template<typename Net>
+template<typename Net, http::BuffersPolicyType Policy = http::DefaultBuffersPolicy>
 class WebSocket {
     typename Net::Socket socket;
-    static constexpr size_t receptionBufferSize = 8192;
 
 public:
     explicit WebSocket(typename Net::Socket netSocket) : socket(std::move(netSocket)), started(false) {
@@ -261,7 +261,7 @@ public:
     void write(Frame<Net> frame) { writeData(std::move(frame)); }
 
 private:
-    std::array<std::byte, receptionBufferSize> readBuffer;
+    std::array<std::byte, Policy::receptionBufferSize> readBuffer;
     FrameDecoder decoder;
     std::function<void(std::string_view)> textHandler;
     std::function<void(std::span<const std::byte>)> binaryHandler;

--- a/include/weblink/Messages.hpp
+++ b/include/weblink/Messages.hpp
@@ -3,6 +3,8 @@
 /// @brief Messages exchanged between webfront clients and server
 #pragma once
 
+#include "../http/BuffersPolicy.hpp"
+
 #include <array>
 #include <bit>
 #include <cstddef>
@@ -156,19 +158,27 @@ public:
     [[nodiscard]] size_t getPayloadSize() const { return static_cast<uint16_t>(256 * head.lengthHi + head.lengthLo); }
 };
 
-/// Encodes a list of parameters : parameter 0 is the function name. Sent either by WebFront or by the JS Client
-class FunctionCall : public MessageBase<FunctionCall> {
-    struct Header {
-        Command command = Command::callFunction;
-        uint8_t parametersCount = 0; // parameter 0 is the function name so parametersCount is always at least 1
-        std::array<uint8_t, 2> padding{};
-        uint32_t parametersDataSize = 0;
-    } head;
-    static_assert(sizeof(Header) == 8, "FunctionCall header has to be 8 bytes long");
+/// Shared header layout for function call/return messages
+template<Command Cmd>
+struct FunctionCallHeader {
+    Command command = Cmd;
+    uint8_t parametersCount = 0; // parameter 0 is the function name so parametersCount is always at least 1
+    std::array<uint8_t, 2> padding{};
+    uint32_t parametersDataSize = 0;
+};
+static_assert(sizeof(FunctionCallHeader<Command::callFunction>) == 8, "FunctionCall header has to be 8 bytes long");
 
-    std::array<std::byte, 1024> buffer; // When composing a msg, buffer doesn't represent the payload but some bufferized data
+/// Shared encode/decode logic for FunctionCall and FunctionReturn
+template<typename Derived, Command Cmd, http::BuffersPolicyType Policy>
+class FunctionCallBase : public MessageBase<Derived> {
+public:
+    using Header = FunctionCallHeader<Cmd>;
+
+protected:
+    Header head{};
+    std::array<std::byte, Policy::functionCallBufferSize> buffer{};
     size_t encodeBufferIndex = 0;
-    friend class MessageBase<FunctionCall>;
+    friend class MessageBase<Derived>;
 
     template<typename T>
     constexpr auto typeName() {
@@ -195,7 +205,7 @@ public:
     }
     [[nodiscard]] std::tuple<std::string, std::span<const std::byte>> getFunctionName() const {
         std::string functionName;
-        auto data = payload();
+        auto data = this->payload();
         decodeParameter(functionName, data);
         return {functionName, data};
     }
@@ -211,6 +221,8 @@ public:
         }
 
         [[maybe_unused]] auto encodeType = [&, this](msg::CodedType type, auto size, WebSocketFrame& wsFrame) {
+            if (encodeBufferIndex + 1 + sizeof(size) > buffer.size())
+                throw http::BufferOverflowException("FunctionCall encode buffer overflow");
             wsFrame.addBuffer(std::span(&buffer[encodeBufferIndex], 1 + sizeof(size)));
             buffer[encodeBufferIndex++] = static_cast<std::byte>(type);
             std::copy_n(reinterpret_cast<const std::byte*>(&size), sizeof(size), &buffer[encodeBufferIndex]);
@@ -235,6 +247,8 @@ public:
             std::apply([&](auto&... tupleArgs) { ((encodeParameter(tupleArgs, frame)), ...); }, t);
         }
         else if constexpr (is_same_v<ParamType, bool>) {
+            if (encodeBufferIndex + 1 > buffer.size())
+                throw http::BufferOverflowException("FunctionCall encode buffer overflow");
             frame.addBuffer(span(&buffer[encodeBufferIndex], 1));
             buffer[encodeBufferIndex++] = static_cast<byte>(t ? msg::CodedType::booleanTrue : msg::CodedType::booleanFalse);
             incrementPayloadSize(1);
@@ -242,6 +256,8 @@ public:
         }
         else if constexpr (is_arithmetic_v<ParamType>) {
             double number = t;
+            if (encodeBufferIndex + 1 + sizeof(number) > buffer.size())
+                throw http::BufferOverflowException("FunctionCall encode buffer overflow");
             frame.addBuffer(span(&buffer[encodeBufferIndex], 1 + sizeof(number)));
             buffer[encodeBufferIndex++] = static_cast<byte>(msg::CodedType::number);
             copy_n(reinterpret_cast<const byte*>(&number), sizeof(number), &buffer[encodeBufferIndex]);
@@ -252,8 +268,6 @@ public:
 
         else if constexpr (is_array_v<ParamType>) {
             using ElementType = remove_all_extents_t<ParamType>;
-            //   cout << "Array of " << typeName<ElementType>() << "\n";
-            //   cout << typeName<ParamType>() << " is bounded : " << is_bounded_array_v<ParamType> << "\n";
             if constexpr (is_same_v<ElementType, char>) {
                 if constexpr (is_bounded_array_v<ParamType>)
                     encodeString(t, extent_v<ParamType> - 1);
@@ -339,16 +353,18 @@ public:
     }
 };
 
+/// Encodes a list of parameters : parameter 0 is the function name. Sent either by WebFront or by the JS Client
+template<http::BuffersPolicyType Policy = http::DefaultBuffersPolicy>
+class FunctionCall : public FunctionCallBase<FunctionCall<Policy>, Command::callFunction, Policy> {
+    friend class MessageBase<FunctionCall<Policy>>;
+    friend class FunctionCallBase<FunctionCall<Policy>, Command::callFunction, Policy>;
+};
+
 /// Encodes FunctionCall return values (or exceptions)
-class FunctionReturn : public FunctionCall {
-    struct Header {
-        Command command = Command::functionReturn;
-        uint8_t parametersCount = 0;
-        std::array<uint8_t, 2> padding{};
-        uint32_t parametersDataSize = 0;
-    } head;
-    static_assert(sizeof(Header) == 8, "FunctionReturn header has to be 8 bytes long");
-    friend class MessageBase<FunctionReturn>;
+template<http::BuffersPolicyType Policy = http::DefaultBuffersPolicy>
+class FunctionReturn : public FunctionCallBase<FunctionReturn<Policy>, Command::functionReturn, Policy> {
+    friend class MessageBase<FunctionReturn<Policy>>;
+    friend class FunctionCallBase<FunctionReturn<Policy>, Command::functionReturn, Policy>;
 };
 
 } // namespace webfront::msg

--- a/include/weblink/Messages.hpp
+++ b/include/weblink/Messages.hpp
@@ -180,19 +180,61 @@ protected:
     size_t encodeBufferIndex = 0;
     friend class MessageBase<Derived>;
 
-    template<typename T>
-    constexpr auto typeName() {
-#if defined(_MSC_VER)
-        std::string_view tName = __FUNCSIG__, prefix = "auto __cdecl JSFunction::typeName<", suffix = ">(void)";
-#elif __clang__
-        std::string_view tName = __PRETTY_FUNCTION__, prefix = "auto webfront::JSFunction::typeName() [T = ", suffix = "]";
-#elif defined(__GNUC__)
-        std::string_view tName = __PRETTY_FUNCTION__,
-                         prefix = "constexpr auto webfront::JSFunction::typeName() [with T = ", suffix = "]";
-#endif
-        tName.remove_prefix(prefix.size());
-        tName.remove_suffix(suffix.size());
-        return tName;
+    template<typename SizeType, typename WebSocketFrame>
+    void encodeTypeHeader(msg::CodedType type, SizeType size, WebSocketFrame& frame) {
+        if (encodeBufferIndex + 1 + sizeof(size) > buffer.size())
+            throw http::BufferOverflowException("FunctionCall encode buffer overflow");
+        frame.addBuffer(std::span(&buffer[encodeBufferIndex], 1 + sizeof(size)));
+        buffer[encodeBufferIndex++] = static_cast<std::byte>(type);
+        std::copy_n(reinterpret_cast<const std::byte*>(&size), sizeof(size), &buffer[encodeBufferIndex]);
+        encodeBufferIndex += sizeof(size);
+        incrementPayloadSize(1 + sizeof(size));
+    }
+
+    template<typename WebSocketFrame>
+    void encodeString(const char* str, size_t size, WebSocketFrame& frame) {
+        using namespace std;
+        if (size < 256)
+            encodeTypeHeader(msg::CodedType::smallString, static_cast<uint8_t>(size), frame);
+        else
+            encodeTypeHeader(msg::CodedType::string, static_cast<uint16_t>(size), frame);
+        frame.addBuffer(span(reinterpret_cast<const std::byte*>(str), size));
+        incrementPayloadSize(size);
+        std::cout << "-> encoded to string of size " << size << " in a span.\n";
+    }
+
+    template<typename WebSocketFrame>
+    void encodeBool(bool value, WebSocketFrame& frame) {
+        using namespace std;
+        if (encodeBufferIndex + 1 > buffer.size())
+            throw http::BufferOverflowException("FunctionCall encode buffer overflow");
+        frame.addBuffer(span(&buffer[encodeBufferIndex], 1));
+        buffer[encodeBufferIndex++] = static_cast<byte>(value ? msg::CodedType::booleanTrue : msg::CodedType::booleanFalse);
+        incrementPayloadSize(1);
+        std::cout << "-> encoded to bool of size 1 in a span.";
+    }
+
+    template<typename WebSocketFrame>
+    void encodeNumber(double number, WebSocketFrame& frame) {
+        using namespace std;
+        if (encodeBufferIndex + 1 + sizeof(number) > buffer.size())
+            throw http::BufferOverflowException("FunctionCall encode buffer overflow");
+        frame.addBuffer(span(&buffer[encodeBufferIndex], 1 + sizeof(number)));
+        buffer[encodeBufferIndex++] = static_cast<byte>(msg::CodedType::number);
+        copy_n(reinterpret_cast<const byte*>(&number), sizeof(number), &buffer[encodeBufferIndex]);
+        encodeBufferIndex += sizeof(number);
+        incrementPayloadSize(1 + sizeof(number));
+        std::cout << "-> encoded to number of size " << sizeof(number) << " in a span.";
+    }
+
+    template<typename WebSocketFrame>
+    void encodeException(const std::exception& e, WebSocketFrame& frame) {
+        using namespace std;
+        std::cout << "Exception : " << e.what() << '\n';
+        auto textSize = char_traits<char>::length(e.what());
+        encodeTypeHeader(msg::CodedType::exception, static_cast<uint16_t>(textSize), frame);
+        frame.addBuffer(span(reinterpret_cast<const std::byte*>(e.what()), textSize));
+        incrementPayloadSize(textSize);
     }
 
 public:
@@ -216,83 +258,31 @@ public:
         using ParamType = remove_cvref_t<T>;
         setParametersCount(getParametersCount() + 1);
 
-        if constexpr (is_printable<T>::value) {
-            std::cout << "Param: " << typeName<T>() << " -> " << typeName<ParamType>() << " : " << t << "\n";
-        }
-
-        [[maybe_unused]] auto encodeType = [&, this](msg::CodedType type, auto size, WebSocketFrame& wsFrame) {
-            if (encodeBufferIndex + 1 + sizeof(size) > buffer.size())
-                throw http::BufferOverflowException("FunctionCall encode buffer overflow");
-            wsFrame.addBuffer(std::span(&buffer[encodeBufferIndex], 1 + sizeof(size)));
-            buffer[encodeBufferIndex++] = static_cast<std::byte>(type);
-            std::copy_n(reinterpret_cast<const std::byte*>(&size), sizeof(size), &buffer[encodeBufferIndex]);
-            encodeBufferIndex += sizeof(size);
-            incrementPayloadSize(1 + sizeof(size));
-        };
-
-        [[maybe_unused]] auto encodeString = [&](const char* str, size_t size) constexpr {
-            if (size < 256)
-                encodeType(msg::CodedType::smallString, static_cast<uint8_t>(size), frame);
-            else
-                encodeType(msg::CodedType::string, static_cast<uint16_t>(size), frame);
-            frame.addBuffer(span(reinterpret_cast<const std::byte*>(str), size));
-            incrementPayloadSize(size);
-
-            std::cout << "-> encoded to string of size " << size << " in a span.\n";
-        };
-
         if constexpr (is_tuple_v<ParamType>) {
             uint8_t nbParams = static_cast<uint8_t>(tuple_size<ParamType>::value);
-            encodeType(msg::CodedType::tuple, nbParams, frame);
+            encodeTypeHeader(msg::CodedType::tuple, nbParams, frame);
             std::apply([&](auto&... tupleArgs) { ((encodeParameter(tupleArgs, frame)), ...); }, t);
         }
-        else if constexpr (is_same_v<ParamType, bool>) {
-            if (encodeBufferIndex + 1 > buffer.size())
-                throw http::BufferOverflowException("FunctionCall encode buffer overflow");
-            frame.addBuffer(span(&buffer[encodeBufferIndex], 1));
-            buffer[encodeBufferIndex++] = static_cast<byte>(t ? msg::CodedType::booleanTrue : msg::CodedType::booleanFalse);
-            incrementPayloadSize(1);
-            std::cout << "-> encoded to bool of size " << 1 << " in a span.";
-        }
-        else if constexpr (is_arithmetic_v<ParamType>) {
-            double number = t;
-            if (encodeBufferIndex + 1 + sizeof(number) > buffer.size())
-                throw http::BufferOverflowException("FunctionCall encode buffer overflow");
-            frame.addBuffer(span(&buffer[encodeBufferIndex], 1 + sizeof(number)));
-            buffer[encodeBufferIndex++] = static_cast<byte>(msg::CodedType::number);
-            copy_n(reinterpret_cast<const byte*>(&number), sizeof(number), &buffer[encodeBufferIndex]);
-            encodeBufferIndex += sizeof(number);
-            incrementPayloadSize(1 + sizeof(number));
-            std::cout << "-> encoded to number of size " << sizeof(number) << " in a span.";
-        }
-
+        else if constexpr (is_same_v<ParamType, bool>)
+            encodeBool(t, frame);
+        else if constexpr (is_arithmetic_v<ParamType>)
+            encodeNumber(static_cast<double>(t), frame);
         else if constexpr (is_array_v<ParamType>) {
             using ElementType = remove_all_extents_t<ParamType>;
-            if constexpr (is_same_v<ElementType, char>) {
-                if constexpr (is_bounded_array_v<ParamType>)
-                    encodeString(t, extent_v<ParamType> - 1);
-                else
-                    encodeString(t, char_traits<char>::length(t));
-            }
+            static_assert(is_same_v<ElementType, char>, "Arrays are not supported by JSFunction");
+            if constexpr (is_bounded_array_v<ParamType>)
+                encodeString(t, extent_v<ParamType> - 1, frame);
             else
-                static_assert(is_same_v<ElementType, char>, "Arrays are not supported by JSFunction");
+                encodeString(t, char_traits<char>::length(t), frame);
         }
         else if constexpr (is_same_v<ParamType, const char*>)
-            encodeString(t, char_traits<char>::length(t));
-
+            encodeString(t, char_traits<char>::length(t), frame);
         else if constexpr (is_same_v<ParamType, string> or is_same_v<ParamType, string_view>)
-            encodeString(t.data(), t.size());
-
+            encodeString(t.data(), t.size(), frame);
         else if constexpr (is_pointer_v<ParamType>)
             static_assert(!is_pointer_v<ParamType>, "Pointers cannot be used by JSFunction");
-
-        else if constexpr (is_base_of_v<std::exception, ParamType>) {
-            std::cout << "Exception : " << t.what() << '\n';
-            auto textSize = char_traits<char>::length(t.what());
-            encodeType(msg::CodedType::exception, static_cast<uint16_t>(textSize), frame);
-            frame.addBuffer(span(reinterpret_cast<const std::byte*>(t.what()), textSize));
-            incrementPayloadSize(textSize);
-        }
+        else if constexpr (is_base_of_v<std::exception, ParamType>)
+            encodeException(t, frame);
 
         std::cout << "bufferIndex = " << encodeBufferIndex << " ,payloadSize = " << getPayloadSize() << "\n";
     }

--- a/include/weblink/WebLink.hpp
+++ b/include/weblink/WebLink.hpp
@@ -26,9 +26,9 @@ struct WebLinkEvent {
     std::span<const std::byte> data;
 };
 
-template<typename Net>
+template<typename Net, http::BuffersPolicyType Policy = http::DefaultBuffersPolicy>
 class WebLink {
-    websocket::WebSocket<Net> ws;
+    websocket::WebSocket<Net, Policy> ws;
     WebLinkId id;
     bool sameEndian;
     std::optional<size_t> logSink;
@@ -69,13 +69,13 @@ public:
 
             case msg::Command::callFunction: {
                 log::info("Function called !");
-                auto command = msg::FunctionCall::castFromRawData(data);
+                auto command = msg::FunctionCall<Policy>::castFromRawData(data);
                 auto [functionName, paramData] = command->getFunctionName();
                 try {
                     eventsHandler(WebLinkEvent(WebLinkEvent::Code::cppFunctionCalled, id, functionName, paramData));
                 }
                 catch (const std::out_of_range& e) {
-                    msg::FunctionReturn returnValue;
+                    msg::FunctionReturn<Policy> returnValue;
                     websocket::Frame<Net> frame{std::span(reinterpret_cast<const std::byte*>(returnValue.header().data()), returnValue.header().size())};
         
                     returnValue.encodeParameter(e, frame);

--- a/test/JSFunctionTests.cpp
+++ b/test/JSFunctionTests.cpp
@@ -1,4 +1,5 @@
 #include <catch2/catch_test_macros.hpp>
+#include <http/BuffersPolicy.hpp>
 #include <JsFunction.hpp>
 #include <networking/NetworkingMock.hpp>
 
@@ -48,6 +49,7 @@ struct WebLinkMock {
 
 struct WebFrontMock {
     using Net = networking::NetworkingMock;
+    using BufferPolicy = http::DefaultBuffersPolicy;
     WebLinkMock<WebFrontMock> getLink(WebLinkId id) { return WebLinkMock<WebFrontMock>{id, *this}; }
 };
 

--- a/test/MessagesTests.cpp
+++ b/test/MessagesTests.cpp
@@ -32,7 +32,7 @@ SCENARIO("FunctionCall") {
                                     0x6f, 0x72, 0x6c, 0x64, 0x20, 0x6f, 0x66, 0x20, 0x32, 0x30, 0x32, 0x32};
 
         auto functionCall =
-          msg::FunctionCall::castFromRawData(std::span(reinterpret_cast<const std::byte*>(raw.data()), raw.size()));
+          msg::FunctionCall<>::castFromRawData(std::span(reinterpret_cast<const std::byte*>(raw.data()), raw.size()));
         REQUIRE(functionCall->getParametersCount() == 2);
         REQUIRE(functionCall->getPayloadSize() == 28);
         auto [name, undecodedData] = functionCall->getFunctionName();
@@ -70,7 +70,7 @@ SCENARIO("FunctionCall") {
           0x00, 0x50, 0x76, 0x40};
 
         auto functionCall =
-          msg::FunctionCall::castFromRawData(std::span(reinterpret_cast<const std::byte*>(raw.data()), raw.size()));
+          msg::FunctionCall<>::castFromRawData(std::span(reinterpret_cast<const std::byte*>(raw.data()), raw.size()));
         REQUIRE(functionCall->getParametersCount() == 4);
         REQUIRE(functionCall->getPayloadSize() == 433);
         auto [name, undecodedData] = functionCall->getFunctionName();
@@ -95,11 +95,15 @@ SCENARIO("FunctionReturn") {
     using Net = networking::NetworkingMock;
 
     GIVEN("A FunctionReturn message") {
-        msg::FunctionReturn message;
+        msg::FunctionReturn<> message;
         websocket::Frame<Net> frame{
           std::span(reinterpret_cast<const std::byte*>(message.header().data()), message.header().size())};
         networking::SocketMock socket;
         websocket::WebSocket<Net> ws(socket);
+
+        THEN("Header command byte is functionReturn") {
+            REQUIRE(static_cast<msg::Command>(message.header()[0]) == msg::Command::functionReturn);
+        }
 
         WHEN("An exception is encoded") {
             std::string exceptionText = "Parameter error";
@@ -116,7 +120,7 @@ SCENARIO("FunctionReturn") {
                 websocket::FrameDecoder decoder;
                 REQUIRE(decoder.parse(span(socket.debugBuffer.data(), socket.bufferIndex)));
 
-                auto funcRet = msg::FunctionReturn::castFromRawData(decoder.payload());
+                auto funcRet = msg::FunctionReturn<>::castFromRawData(decoder.payload());
                 REQUIRE(funcRet->getParametersCount() == 1);
                 REQUIRE(funcRet->getPayloadSize() == 3 + exceptionText.size());
 
@@ -137,7 +141,7 @@ SCENARIO("FunctionReturn") {
             THEN("An erroneous tuple should trigger an exception") {
                 websocket::FrameDecoder decoder;
                 REQUIRE(decoder.parse(span(socket.debugBuffer.data(), socket.bufferIndex)));
-                auto funcRet = msg::FunctionReturn::castFromRawData(decoder.payload());
+                auto funcRet = msg::FunctionReturn<>::castFromRawData(decoder.payload());
                 std::tuple<int, std::string, int> tupleValue;
                 auto undecodedData = funcRet->payload();
                 REQUIRE_THROWS_AS(funcRet->decodeParameter(tupleValue, undecodedData), std::runtime_error);
@@ -145,7 +149,7 @@ SCENARIO("FunctionReturn") {
             THEN("A Frame decoded should retrieve the encoded parameters") {
                 websocket::FrameDecoder decoder;
                 REQUIRE(decoder.parse(span(socket.debugBuffer.data(), socket.bufferIndex)));
-                auto funcRet = msg::FunctionReturn::castFromRawData(decoder.payload());
+                auto funcRet = msg::FunctionReturn<>::castFromRawData(decoder.payload());
                 REQUIRE(funcRet->getParametersCount() == 3);
                 REQUIRE(funcRet->getPayloadSize() == 24);
 
@@ -156,6 +160,45 @@ SCENARIO("FunctionReturn") {
                 REQUIRE(std::get<1>(tupleValue) == "Hello World");
                 std::cout << undecodedData.size() << "\n";
                 REQUIRE(undecodedData.empty());
+            }
+        }
+    }
+}
+
+SCENARIO("BufferOverflow") {
+    using Net = networking::NetworkingMock;
+    using TinyPolicy = http::CustomBuffersPolicy<8192, 8192, 12>;
+
+    GIVEN("A FunctionCall with a tiny buffer") {
+        msg::FunctionCall<TinyPolicy> message;
+        websocket::Frame<Net> frame{
+          std::span(reinterpret_cast<const std::byte*>(message.header().data()), message.header().size())};
+
+        WHEN("Number overflows the buffer") {
+            message.encodeParameter("fn", frame);   // 2 bytes in buffer (type + uint8 size)
+            message.encodeParameter(1, frame);       // 9 bytes in buffer (type + double) → total 11
+
+            THEN("Next number overflows") {
+                REQUIRE_THROWS_AS(message.encodeParameter(2, frame), http::BufferOverflowException);
+            }
+        }
+
+        WHEN("Boolean overflows the buffer") {
+            message.encodeParameter("fn", frame);   // 2 bytes → total 2
+            message.encodeParameter(1, frame);       // 9 bytes → total 11
+            message.encodeParameter(true, frame);    // 1 byte  → total 12 (exactly full)
+
+            THEN("Next boolean overflows") {
+                REQUIRE_THROWS_AS(message.encodeParameter(false, frame), http::BufferOverflowException);
+            }
+        }
+
+        WHEN("String header overflows the buffer") {
+            message.encodeParameter("fn", frame);   // 2 bytes → total 2
+            message.encodeParameter(1, frame);       // 9 bytes → total 11
+
+            THEN("Next string header overflows") {
+                REQUIRE_THROWS_AS(message.encodeParameter("x", frame), http::BufferOverflowException);
             }
         }
     }


### PR DESCRIPTION
Introduce a `BuffersPolicyType` concept and thread it through the full template chain, making all internal buffer sizes configurable at compile time.

### Changes

- **New `BuffersPolicy.hpp`**: `BuffersPolicyType` concept, `DefaultBuffersPolicy`, `CustomBuffersPolicy<R,E,F>`, `BufferOverflowException`
- **Policy propagation**: `BasicWF` → `Server`/`Connection` (reception buffer), `WebLink` → `WebSocket` (reception buffer), `FunctionCall`/`FunctionReturn` (encoding buffer)
- **Overflow detection**: `encodeParameter` throws `BufferOverflowException` when the encoding buffer is exhausted
- **New test**: `BufferOverflow` scenario validates exception with a tiny custom policy

### Defaults (per issue #40)

| Buffer | Size |
|--------|------|
| receptionBufferSize | 8192 |
| emissionBufferSize | 8192 |
| functionCallBufferSize | 32768 |

### Usage

```cpp
// Default policy (backward compatible — no changes needed)
BasicWF<NetProvider, fs::IndexFS> webFront(port, docRoot);

// Custom policy
using MyPolicy = http::CustomBuffersPolicy<16384, 16384, 65536>;
BasicWF<NetProvider, fs::IndexFS, MyPolicy> webFront(port, docRoot);
```

All 39 tests pass. Full backward compatibility via default template parameters.

Supersedes #192.
Fixes #40