### PR TITLE
Add generic frontend abstraction

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,14 @@ WebFront implements the websocket protocol over an embedded Web server and provi
 
 ```
 
+#### Choosing a frontend
+`webfront::WebFront` still uses the default frontend selected at build time. To force a specific frontend in user code, use `WebFrontWithFrontend` or `BasicWFWithFrontend`:
+
+```cpp
+using BrowserFront = webfront::WebFrontWithFrontend<webfront::frontend::DefaultBrowserFrontend>;
+using EmbeddedFront = webfront::WebFrontWithFrontend<webfront::frontend::CEFFrontend>;
+```
+
 ## Building and Testing
 
 ### Build Configuration
@@ -66,12 +74,12 @@ cd build
 ./src/WebFrontApp
 ```
 
-When built with `WEBFRONT_EMBED_CEF=ON` (default), this opens a clean chromeless application window. When built with `WEBFRONT_EMBED_CEF=OFF`, it opens in your system browser. The application provides:
-- ✅ **Unified API**: `webfront::open()` automatically uses the best available window type
-- ✅ **Chromeless UI**: Clean application window without browser chrome elements (CEF only)
-- ✅ **React Support**: Full React 18 + JSX + Babel transpilation
-- ✅ **C++/JS Interop**: Bidirectional function calls between C++ and JavaScript
-- ✅ **TypeScript Ready**: Modern JavaScript features and type support
+When built with `WEBFRONT_EMBED_CEF=ON`, this opens a clean chromeless application window. When built with `WEBFRONT_EMBED_CEF=OFF`, it opens in your system browser. The application provides:
+- **Unified API**: `webfront::WebFront` picks the default frontend, and `webfront::WebFrontWithFrontend<>` can force one explicitly
+- **Chromeless UI**: Clean application window without browser chrome elements (CEF only)
+- **React Support**: Full React 18 + JSX + Babel transpilation
+- **C++/JS Interop**: Bidirectional function calls between C++ and JavaScript
+- **TypeScript Ready**: Modern JavaScript features and type support
 
 #### webtest - Jasmine Test Runner with Embedded Window  
 Run the JavaScript test suite in an embedded CEF window for automated testing:

--- a/include/WebFront.hpp
+++ b/include/WebFront.hpp
@@ -3,8 +3,7 @@
 /// @brief WebFront UI main objet
 #pragma once
 
-#include "frontend/CEF.hpp"
-#include "frontend/DefaultBrowser.hpp"
+#include "frontend/Frontend.hpp"
 #include "http/HTTPServer.hpp"
 #include "JsFunction.hpp"
 #include "networking/TCPNetworkingTS.hpp"
@@ -17,13 +16,13 @@
 #include <filesystem>
 #include <functional>
 #include <map>
+#include <mutex>
 #include <span>
+#include <stdexcept>
 #include <string>
 #include <string_view>
 #include <thread>
 #include <tuple>
-#include <stdexcept>
-#include <thread>
 #include <utility>
 
 namespace webfront {
@@ -65,37 +64,28 @@ public:
     }
 };
 
-// Global initialization helper to ensure CEF initializes before any networking
 namespace detail {
-inline int ensureCEFInitialized() {
-    if constexpr (cef::webfrontEmbedCEF) {
-        static bool initialized = false;
-        if (!initialized) {
-            try {
-                cef::initialize();
-                initialized = true;
-            } catch (const cef::CEFSubprocessExit& e) {
-                // If this is a CEF subprocess, exit immediately
-                std::exit(e.exit_code());
-            } catch (const cef::CEFInitializationError& e) {
-                // CEF initialization failed - this is a fatal error
-                throw std::runtime_error(e.what());
-            }
-        }
-    }
-    return 0;  // Return value for comma operator
+template <frontend::FrontendType Frontend>
+inline int ensureFrontendInitialized() {
+    static std::once_flag initialized;
+    std::call_once(initialized, [] {
+        Frontend::initialize();
+    });
+    return 0;
 }
 }  // namespace detail
 
-template <typename NetProvider, typename Filesystem, http::BuffersPolicyType Policy = http::DefaultBuffersPolicy>
+template <typename NetProvider, typename Filesystem, http::BuffersPolicyType Policy = http::DefaultBuffersPolicy,
+          frontend::FrontendType Frontend = frontend::DefaultFrontend>
 class BasicWF {
 public:
-    using Net          = NetProvider;
-    using BufferPolicy = Policy;
-    using UI           = BasicUI<BasicWF<Net, Filesystem, Policy>>;
+    using Net              = NetProvider;
+    using BufferPolicy     = Policy;
+    using FrontendProvider = Frontend;
+    using UI               = BasicUI<BasicWF<Net, Filesystem, Policy, Frontend>>;
 
     explicit BasicWF(std::string_view port, std::filesystem::path docRoot = ".")
-        : httpServer((detail::ensureCEFInitialized(), "0.0.0.0"), port, docRoot), httpPort(port), httpDocRoot(docRoot), idsCounter(0) {
+        : httpServer((detail::ensureFrontendInitialized<Frontend>(), "0.0.0.0"), port, docRoot), httpPort(port), httpDocRoot(docRoot), idsCounter(0) {
         httpServer.onUpgrade([this](typename Net::Socket&& socket, http::Protocol protocol) {
             if (protocol == http::Protocol::WebSocket)
                 for (bool inserted = false; !inserted; ++idsCounter)
@@ -153,13 +143,8 @@ public:
 
     enum class WindowAction { none, closeWindow };
     WindowAction openWindow(std::string_view htmlFilename) {
-        if constexpr (cef::webfrontEmbedCEF) {
-            cef::open(httpPort, htmlFilename);  // Blocking until window closed
-            return WindowAction::closeWindow;
-        } else {
-            browser::open(httpPort, htmlFilename);  // Non-blocking external browser
-            return WindowAction::none;
-        };
+        Frontend::open(httpPort, htmlFilename);
+        return Frontend::action == frontend::Action::closeServerAfterOpen ? WindowAction::closeWindow : WindowAction::none;
     }
 
     // Starts the HTTP server in a background thread, opens the window (blocking for embedded CEF),
@@ -205,7 +190,12 @@ private:
     }
 };
 
+template <typename NetProvider, typename Filesystem, frontend::FrontendType Frontend, http::BuffersPolicyType Policy = http::DefaultBuffersPolicy>
+using BasicWFWithFrontend = BasicWF<NetProvider, Filesystem, Policy, Frontend>;
+
 using WebFront = BasicWF<NetProvider, fs::IndexFS>;
+template <frontend::FrontendType Frontend, http::BuffersPolicyType Policy = http::DefaultBuffersPolicy>
+using WebFrontWithFrontend = BasicWF<NetProvider, fs::IndexFS, Policy, Frontend>;
 using UI       = WebFront::UI;
 
 }  // namespace webfront

--- a/include/WebFront.hpp
+++ b/include/WebFront.hpp
@@ -144,7 +144,10 @@ public:
     enum class WindowAction { none, closeWindow };
     WindowAction openWindow(std::string_view htmlFilename) {
         Frontend::open(httpPort, htmlFilename);
-        return Frontend::action == frontend::Action::closeServerAfterOpen ? WindowAction::closeWindow : WindowAction::none;
+        if constexpr (Frontend::action == frontend::Action::closeServerAfterOpen)
+            return WindowAction::closeWindow;
+        else
+            return WindowAction::none;
     }
 
     // Starts the HTTP server in a background thread, opens the window (blocking for embedded CEF),

--- a/include/frontend/CEF.hpp
+++ b/include/frontend/CEF.hpp
@@ -213,7 +213,7 @@ inline CefMainArgs makeMainArgs(
 // Throws: CEFInitializationError on initialization failure
 // Throws: CEFSubprocessExit if this is a subprocess (caller should exit with the provided code)
 // Returns: void on successful main process initialization
-void initialize() {
+inline void initialize() {
     if constexpr (!webfrontEmbedCEF) {
         return;
     }
@@ -378,7 +378,7 @@ private:
     #endif
 };
 
-void open(std::string_view port, std::string_view file) {
+inline void open(std::string_view port, std::string_view file) {
     if constexpr (!webfrontEmbedCEF) {
         throw std::runtime_error("cef::open() : CEF not available");
     }
@@ -444,11 +444,11 @@ namespace webfront::cef {
 static constexpr bool webfrontEmbedCEF{false};
 
 // Stub implementations for when CEF is not available
-void initialize() {
+inline void initialize() {
     // No-op when CEF is not available
 }
 
-void open(std::string_view /*port*/, std::string_view /*file*/) {
+inline void open(std::string_view /*port*/, std::string_view /*file*/) {
     throw std::runtime_error("cef::open() : CEF not available");
 }
 

--- a/include/frontend/DefaultBrowser.hpp
+++ b/include/frontend/DefaultBrowser.hpp
@@ -8,7 +8,7 @@
 
 namespace webfront::browser {
 /// Check if running under WSL
-bool isWSL() {
+inline bool isWSL() {
     std::ifstream proc_version("/proc/version");
     if (proc_version.is_open()) {
         std::string version_info;
@@ -20,7 +20,7 @@ bool isWSL() {
 }
 
 /// Open the web UI in the system's default browser (blocking until user closes)
-void open(std::string_view port, std::string_view file) {
+inline void open(std::string_view port, std::string_view file) {
     std::string command;
     
 #ifdef _WIN32

--- a/include/frontend/Frontend.hpp
+++ b/include/frontend/Frontend.hpp
@@ -1,0 +1,55 @@
+#pragma once
+
+#include "CEF.hpp"
+#include "DefaultBrowser.hpp"
+
+#include <concepts>
+#include <cstdlib>
+#include <string_view>
+#include <type_traits>
+
+namespace webfront::frontend {
+
+enum class Action {
+    keepServerRunning,
+    closeServerAfterOpen
+};
+
+template <typename Frontend>
+concept FrontendType = requires(std::string_view port, std::string_view file) {
+    { Frontend::initialize() } -> std::same_as<void>;
+    { Frontend::open(port, file) } -> std::same_as<void>;
+} && std::same_as<std::remove_cvref_t<decltype(Frontend::action)>, Action>;
+
+// `action` describes what BasicWF should do after `open()` returns.
+// Keep the server running when `open()` only launches the UI, and ask BasicWF to
+// stop it when `open()` returns after the UI session is finished.
+struct DefaultBrowserFrontend {
+    static constexpr Action action{Action::keepServerRunning};
+
+    static void initialize() {}
+
+    static void open(std::string_view port, std::string_view file) {
+        browser::open(port, file);
+    }
+};
+
+struct CEFFrontend {
+    static constexpr Action action{Action::closeServerAfterOpen};
+
+    static void initialize() {
+        try {
+            cef::initialize();
+        } catch (const cef::CEFSubprocessExit& e) {
+            std::exit(e.exit_code());
+        }
+    }
+
+    static void open(std::string_view port, std::string_view file) {
+        cef::open(port, file);
+    }
+};
+
+using DefaultFrontend = std::conditional_t<cef::webfrontEmbedCEF, CEFFrontend, DefaultBrowserFrontend>;
+
+}  // namespace webfront::frontend

--- a/include/networking/NetworkingMock.hpp
+++ b/include/networking/NetworkingMock.hpp
@@ -28,7 +28,11 @@ public:
     // auto reuse_address(bool reuse) { return reuse ? "SO_REUSEADDR:1" : "SO_REUSEADDR:0"; }
     struct reuse_address {
         bool isSet;
-        bool value() { return isSet; }
+
+        explicit reuse_address(bool reuse)
+            : isSet(reuse) {}
+
+        bool value() const { return isSet; }
     };
     void set_option(reuse_address option) { log::debug("SocketBaseMock::set_option(reuse_address({}))", option.value()); }
     void bind(const EndpointMock&) { log::debug("SocketBaseMock::bind()"); }

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -11,6 +11,7 @@ set(TESTS_LIST)
 list(APPEND TESTS_LIST HTTPServerTests.cpp EncodingsTests.cpp WebSocketTests.cpp LoggerTests.cpp MimeTypeTests.cpp)
 list(APPEND TESTS_LIST JSFunctionTests.cpp TypeErasedFunctionTests.cpp MessagesTests.cpp IndexFSTests.cpp)
 list(APPEND TESTS_LIST JasmineFSTests.cpp FileSystemTests.cpp NativeFSTests.cpp ReactFSTests.cpp BabelFSTests.cpp)
+list(APPEND TESTS_LIST WebFrontTests.cpp)
 add_executable(tests ${TESTS_LIST})
 target_link_libraries(tests PRIVATE WebFront_warnings WebFront_options Catch2::Catch2WithMain WebFront)
 

--- a/test/WebFrontTests.cpp
+++ b/test/WebFrontTests.cpp
@@ -1,0 +1,171 @@
+#include <catch2/catch_test_macros.hpp>
+#include <tooling/Logger.hpp>
+#include <networking/NetworkingMock.hpp>
+#include <WebFront.hpp>
+
+#include "Mocks.hpp"
+
+#include <list>
+#include <string>
+#include <type_traits>
+
+using namespace webfront;
+
+namespace {
+
+using TestFilesystem = MockFileSystem<>;
+
+class WebFrontIoContextMock {
+public:
+    void run() {}
+    void run_one() {}
+    void stop() {}
+};
+
+class WebFrontResolverMock {
+public:
+    explicit WebFrontResolverMock(WebFrontIoContextMock) {}
+
+    std::list<networking::EndpointMock> resolve(std::string_view address, std::string_view port) {
+        return {networking::EndpointMock{address, port}};
+    }
+};
+
+class WebFrontAcceptorMock : public networking::SocketBaseMock {
+    bool openState = false;
+
+public:
+    explicit WebFrontAcceptorMock(WebFrontIoContextMock) {}
+
+    void open(auto protocol) {
+        log::debug("WebFrontAcceptorMock::open({})", protocol);
+        openState = true;
+    }
+
+    void async_accept(std::function<void(std::error_code, networking::SocketMock)>) {}
+
+    bool is_open() const { return openState; }
+
+    void close() { openState = false; }
+};
+
+class WebFrontNetworkingMock : public networking::NetworkingMock {
+public:
+    using Acceptor  = WebFrontAcceptorMock;
+    using IoContext = WebFrontIoContextMock;
+    using Resolver  = WebFrontResolverMock;
+};
+
+struct InitializingFrontend {
+    static inline int initializeCalls = 0;
+    static constexpr frontend::Action action{frontend::Action::keepServerRunning};
+
+    static void initialize() {
+        ++initializeCalls;
+    }
+
+    static void open(std::string_view, std::string_view) {}
+};
+
+struct OpeningFrontend {
+    static inline int initializeCalls = 0;
+    static inline int openCalls       = 0;
+    static inline std::string lastPort;
+    static inline std::string lastFile;
+    static constexpr frontend::Action action{frontend::Action::keepServerRunning};
+
+    static void initialize() {
+        ++initializeCalls;
+    }
+
+    static void open(std::string_view port, std::string_view file) {
+        ++openCalls;
+        lastPort = std::string(port);
+        lastFile = std::string(file);
+    }
+};
+
+struct ClosingFrontend {
+    static inline int initializeCalls = 0;
+    static inline int openCalls       = 0;
+    static inline std::string lastPort;
+    static inline std::string lastFile;
+    static constexpr frontend::Action action{frontend::Action::closeServerAfterOpen};
+
+    static void initialize() {
+        ++initializeCalls;
+    }
+
+    static void open(std::string_view port, std::string_view file) {
+        ++openCalls;
+        lastPort = std::string(port);
+        lastFile = std::string(file);
+    }
+};
+
+}  // namespace
+
+SCENARIO("Frontend selection aliases") {
+    THEN("the default frontend follows the CEF availability") {
+        if constexpr (cef::webfrontEmbedCEF)
+            REQUIRE(std::is_same_v<frontend::DefaultFrontend, frontend::CEFFrontend>);
+        else
+            REQUIRE(std::is_same_v<frontend::DefaultFrontend, frontend::DefaultBrowserFrontend>);
+    }
+
+    THEN("the convenience alias keeps the selected frontend type") {
+        using FrontendWF = BasicWFWithFrontend<WebFrontNetworkingMock, TestFilesystem, OpeningFrontend>;
+        REQUIRE(std::is_same_v<typename FrontendWF::FrontendProvider, OpeningFrontend>);
+    }
+}
+
+SCENARIO("BasicWF initializes a custom frontend once") {
+    GIVEN("two BasicWF instances sharing the same frontend type") {
+        using FrontendWF = BasicWFWithFrontend<WebFrontNetworkingMock, TestFilesystem, InitializingFrontend>;
+
+        WHEN("they are constructed") {
+            FrontendWF first("8080");
+            FrontendWF second("8081");
+
+            THEN("the frontend initialization runs only once") {
+                REQUIRE(InitializingFrontend::initializeCalls == 1);
+            }
+        }
+    }
+}
+
+SCENARIO("BasicWF delegates window opening to the selected frontend") {
+    GIVEN("a frontend that keeps the server running after open") {
+        using FrontendWF = BasicWFWithFrontend<WebFrontNetworkingMock, TestFilesystem, OpeningFrontend>;
+        FrontendWF webFront("8123");
+
+        WHEN("openWindow is called") {
+            auto action = webFront.openWindow("index.html");
+
+            THEN("the frontend receives the request and keeps the server alive") {
+                REQUIRE(action == FrontendWF::WindowAction::none);
+                REQUIRE(OpeningFrontend::initializeCalls == 1);
+                REQUIRE(OpeningFrontend::openCalls == 1);
+                REQUIRE(OpeningFrontend::lastPort == "8123");
+                REQUIRE(OpeningFrontend::lastFile == "index.html");
+            }
+        }
+    }
+
+    GIVEN("a frontend that completes when the window session ends") {
+        using FrontendWF = BasicWFWithFrontend<WebFrontNetworkingMock, TestFilesystem, ClosingFrontend>;
+        FrontendWF webFront("9000");
+
+        WHEN("openWindow is called") {
+            auto action = webFront.openWindow("react.html");
+
+            THEN("BasicWF requests server shutdown after the frontend returns") {
+                REQUIRE(action == FrontendWF::WindowAction::closeWindow);
+                REQUIRE(ClosingFrontend::initializeCalls == 1);
+                REQUIRE(ClosingFrontend::openCalls == 1);
+                REQUIRE(ClosingFrontend::lastPort == "9000");
+                REQUIRE(ClosingFrontend::lastFile == "react.html");
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Related issue(s)

Closes #135

## Implementation summary

- Added `include/frontend/Frontend.hpp` with `frontend::Action`, `FrontendType`, `DefaultBrowserFrontend`, `CEFFrontend`, and `DefaultFrontend`.
- Updated `include/WebFront.hpp` to initialize and open the UI through the selected frontend, use `std::call_once`, and expose `BasicWFWithFrontend` / `WebFrontWithFrontend`.
- Added `test/WebFrontTests.cpp` and `test/CMakeLists.txt` coverage for default frontend selection, one-time initialization, and `openWindow()` action mapping.
- Updated `README.md` with explicit frontend-selection examples; no breaking change, existing `BasicWF<Net, FS, Policy>` call sites stay valid.

## Impacted modules

**Directly modified:** - [x] `include/WebFront.hpp`, `include/frontend/Frontend.hpp` - frontend abstraction and lifecycle wiring. - [x] `test/WebFrontTests.cpp`, `test/CMakeLists.txt` - regression coverage for custom/default frontends. - [x] `README.md` - public usage examples.
**Indirectly impacted (dependencies, API changes, behavior changes):** - [x] `frontend/CEF.hpp`, `frontend/DefaultBrowser.hpp` - reused through wrappers, public helpers preserved.
**Requires regression testing:** - [x] `WebFront` startup/opening flow - template selection and post-open behavior now depend on the frontend type.

## Testing

- [x] All acceptance criteria from issue met
- [ ] Manual testing performed and results documented below
**Test results summary:** `cmake -S . -B build-copilot-135 -DWEBFRONT_EMBED_CEF=OFF && cmake --build build-copilot-135 --parallel && cd build-copilot-135 && ctest --output-on-failure` -> 42 tests passed.

## Documentation

- [x] API documentation updated (if applicable); [x] README/user documentation updated (if applicable)
- [ ] Code comments updated; [ ] ADR created/updated (if applicable)

## Code quality checklist

- [x] Security considerations addressed; [x] Performance impact acceptable (if applicable); [ ] Memory leaks checked (if applicable)

/label ~"status::review_needed"
