### PR TITLE
Finish native JavaScript module demo [#132]

### DIFF
--- a/src/HelloWorld.cpp
+++ b/src/HelloWorld.cpp
@@ -9,6 +9,7 @@
 
 #include <filesystem>
 #include <iostream>
+#include <optional>
 #include <string>
 #include <stdexcept>
 
@@ -16,37 +17,40 @@ using namespace std;
 using namespace webfront;
 
 
-int main(int /*argc*/, char** /*argv*/) {
+// LCOV_EXCL_START - interactive example; behavior is covered by the browser integration target.
+int main(int argc, char** argv) {
     using HelloFS     = fs::Multi<fs::NativeDebugFS, fs::IndexFS, fs::ReactFS, fs::BabelFS>;
     using WebFrontDbg = BasicWF<NetProvider, HelloFS>;
 
     const string httpPort = "9002";
-    const string mainHtml = "react.html";
+    const string mainHtml = argc > 1 ? argv[1] : "module-demo.html";
     auto docRoot  = tooling::findDocRoot(mainHtml);
 
     cout << "WebFront launched from " << filesystem::current_path().string() << "\n";
     log::setLogLevel(log::Debug);
     log::addSinks(log::clogSink);
     WebFrontDbg webFront(httpPort, docRoot);
+    optional<WebFrontDbg::UI> connectedUI;
 
     webFront.cppFunction<void, std::string>("print", [](const std::string& text) {
         std::cout << text << '\n';
     });
-    webFront.onUIStarted([](WebFrontDbg::UI ui) {
-        ui.addScript("var addText = function(text, num) {                 \n"
-                     "  let print = webFront.cppFunction('print');        \n"
-                     "  print(text + ' of ' + num);                       \n"
-                     "}                                                   \n"
-                     "                                                    \n"
-                     "var testFunc = function(text) {                     \n"
-                     "  let bigText = 'bigText : ' + text + text + ' - '; \n"
-                     "  bigText += bigText + bigText;                     \n"
-                     "  let cppTest = webFront.cppFunction('cppTest');    \n"
-                     "  cppTest(text, bigText, bigText.length);           \n"
-                     "}                                                   \n");
-        auto print = ui.jsFunction("addText");
-        print("Hello World", 2025);
-        ui.jsFunction("testFunc")("Texte de test suffisament long pour changer de format");
+    webFront.cppFunction<void>("moduleReady", [&connectedUI] {
+        if (connectedUI)
+            connectedUI->jsFunction("webfrontModule.receiveFromCpp")("Hello from C++ through WebFront");
+    });
+
+    const bool useReactExample = filesystem::path(mainHtml).filename() == "react.html";
+    webFront.onUIStarted([&connectedUI, useReactExample](WebFrontDbg::UI ui) {
+        connectedUI.emplace(ui);
+        if (!useReactExample)
+            return;
+
+        ui.addScript("var addText = function(text, num) {          \n"
+                     "  const print = webFront.cppFunction('print');\n"
+                     "  print(text + ' of ' + num);                \n"
+                     "}                                            \n");
+        ui.jsFunction("addText")("Hello World", 2025);
     });
 
     webFront.openAndRun(mainHtml);
@@ -55,3 +59,4 @@ int main(int /*argc*/, char** /*argv*/) {
 
     return 0;
 }
+// LCOV_EXCL_STOP

--- a/src/module-demo.html
+++ b/src/module-demo.html
@@ -1,0 +1,69 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>WebFront ES Modules Demo</title>
+    <script src="WebFront.js"></script>
+    <style>
+        :root {
+            color-scheme: dark;
+            font-family: Arial, Helvetica, sans-serif;
+        }
+        body {
+            margin: 0;
+            min-height: 100vh;
+            display: grid;
+            place-items: center;
+            background: #0f172a;
+            color: #e2e8f0;
+        }
+        .panel {
+            width: min(90vw, 38rem);
+            padding: 2rem;
+            border-radius: 1rem;
+            background: #111827;
+            box-shadow: 0 1.5rem 4rem rgba(15, 23, 42, 0.35);
+        }
+        h1 {
+            margin-top: 0;
+        }
+        p {
+            color: #cbd5e1;
+            line-height: 1.5;
+        }
+        .stack {
+            display: grid;
+            gap: 0.75rem;
+        }
+        input,
+        button {
+            font: inherit;
+            padding: 0.75rem 1rem;
+            border-radius: 0.75rem;
+            border: 1px solid #334155;
+        }
+        input {
+            background: #020617;
+            color: inherit;
+        }
+        button {
+            cursor: pointer;
+            background: #4f46e5;
+            color: white;
+        }
+        .status {
+            min-height: 1.5rem;
+            color: #93c5fd;
+        }
+        .module-note {
+            font-size: 0.95rem;
+            color: #94a3b8;
+        }
+    </style>
+</head>
+<body>
+    <div id="root"></div>
+    <script type="module" src="modules/main.mjs"></script>
+</body>
+</html>

--- a/src/modules/bridge.mjs
+++ b/src/modules/bridge.mjs
@@ -1,0 +1,22 @@
+export function sendToCpp(message) {
+    const payload = message || 'Hello from ES modules';
+    if (window.webFront && typeof window.webFront.cppFunction === 'function') {
+        window.webFront.cppFunction('print')(payload);
+        return `Sent to C++: ${payload}`;
+    }
+
+    console.log(payload);
+    return `Console fallback: ${payload}`;
+}
+
+export function installCppBridge(onMessage) {
+    globalThis.webfrontModule = {
+        receiveFromCpp(message) {
+            onMessage(message);
+        }
+    };
+
+    if (globalThis.webFront && typeof globalThis.webFront.cppFunction === 'function') {
+        globalThis.webFront.cppFunction('moduleReady')();
+    }
+}

--- a/src/modules/main.mjs
+++ b/src/modules/main.mjs
@@ -1,0 +1,11 @@
+import { installCppBridge, sendToCpp } from './bridge.mjs';
+import { renderDemo } from './ui.mjs';
+
+const root = document.getElementById('root');
+
+if (!root) {
+    throw new Error('The module demo root element is missing.');
+}
+
+const demo = renderDemo(root, sendToCpp);
+installCppBridge(demo.showFromCpp);

--- a/src/modules/messages.mjs
+++ b/src/modules/messages.mjs
@@ -1,0 +1,9 @@
+const notes = [
+    'Loaded through <script type="module">',
+    'Imported from ./messages.mjs',
+    'Resolved relative to the importing module'
+];
+
+export function importedModuleNote() {
+    return notes.join(' | ');
+}

--- a/src/modules/ui.mjs
+++ b/src/modules/ui.mjs
@@ -1,0 +1,47 @@
+import { importedModuleNote } from './messages.mjs';
+
+function createElement(tagName, options = {}) {
+    const element = document.createElement(tagName);
+    if (options.className) {
+        element.className = options.className;
+    }
+    if (options.textContent) {
+        element.textContent = options.textContent;
+    }
+    return element;
+}
+
+export function renderDemo(root, onSend) {
+    const panel = createElement('main', { className: 'panel' });
+    const title = createElement('h1', { textContent: 'ES modules served by WebFront' });
+    const description = createElement('p', {
+        textContent: 'This page is bootstrapped by a single entry module that imports other .mjs files using relative paths.'
+    });
+    const moduleNote = createElement('p', {
+        className: 'module-note',
+        textContent: importedModuleNote()
+    });
+    const controls = createElement('div', { className: 'stack' });
+    const inputLabel = createElement('label', { textContent: 'Message for C++' });
+    const input = document.createElement('input');
+    input.id = 'cpp-message';
+    inputLabel.htmlFor = input.id;
+    input.placeholder = 'Type a message for C++';
+    input.value = 'Hello from ES modules';
+    const button = createElement('button', { textContent: 'Send to C++' });
+    const status = createElement('div', { className: 'status', textContent: 'Waiting for C++…' });
+
+    button.addEventListener('click', () => {
+        status.textContent = onSend(input.value.trim());
+    });
+
+    controls.append(inputLabel, input, button, status);
+    panel.append(title, description, moduleNote, controls);
+    root.replaceChildren(panel);
+
+    return {
+        showFromCpp(message) {
+            status.textContent = `Received from C++: ${message}`;
+        }
+    };
+}

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -8,7 +8,7 @@ find_package(Threads)
 include(CTest)
 
 set(TESTS_LIST)
-list(APPEND TESTS_LIST HTTPServerTests.cpp EncodingsTests.cpp WebSocketTests.cpp LoggerTests.cpp MimeTypeTests.cpp)
+list(APPEND TESTS_LIST HTTPServerTests.cpp ModuleHTTPServerTests.cpp EncodingsTests.cpp WebSocketTests.cpp LoggerTests.cpp MimeTypeTests.cpp)
 list(APPEND TESTS_LIST JSFunctionTests.cpp TypeErasedFunctionTests.cpp MessagesTests.cpp IndexFSTests.cpp)
 list(APPEND TESTS_LIST JasmineFSTests.cpp FileSystemTests.cpp NativeFSTests.cpp ReactFSTests.cpp BabelFSTests.cpp)
 list(APPEND TESTS_LIST WebFrontTests.cpp)

--- a/test/HTTPServerTests.cpp
+++ b/test/HTTPServerTests.cpp
@@ -283,4 +283,5 @@ SCENARIO("RequestHandler on a HTTP GET") {
             }
         }
     }
+
 }

--- a/test/ModuleHTTPServerTests.cpp
+++ b/test/ModuleHTTPServerTests.cpp
@@ -1,0 +1,31 @@
+#include "Mocks.hpp"
+#include <catch2/catch_test_macros.hpp>
+#include <http/HTTPServer.hpp>
+#include <networking/NetworkingMock.hpp>
+
+#include <list>
+#include <string>
+
+using namespace webfront;
+using namespace webfront::http;
+using Net = networking::NetworkingMock;
+
+namespace {
+struct ModuleFile {
+    static inline std::list names{"modules/main.mjs"};
+};
+}  // namespace
+
+SCENARIO("RequestHandler serves JavaScript modules") {
+    std::string input{"GET /modules/main.mjs HTTP/1.1\r\nHost: localhost\r\nAccept-encoding: gzip, br, deflate\r\n\r\n"};
+    Request     request;
+    REQUIRE_NOTHROW(request.parseSomeData(input.cbegin(), input.cend()));
+
+    RequestHandler<Net, MockFileSystem<ModuleFile>> handler{"."};
+    auto                                            response = handler.handleRequest(request);
+
+    REQUIRE(response.statusCode == Response::ok);
+    REQUIRE(response.getHeaderValue("Content-Encoding") == "br");
+    REQUIRE(response.getHeaderValue("Content-Type") == "application/javascript");
+    REQUIRE(response.getHeaderValue("Content-Length") == "0");
+}


### PR DESCRIPTION
## Summary
- serve a native ES module graph with relative imports
- make the module demo the default WebFrontApp page
- demonstrate JavaScript-to-C++ and C++-to-served-JavaScript calls
- cover .mjs responses and their JavaScript MIME type

## Testing
- CEF-off build completed successfully
- all 44 Catch2 scenarios passed
- module JavaScript syntax checks passed

Closes #132