### PR TITLE
Document project status and contributor guidance

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,3 @@
+# GitHub Copilot instructions
+
+Read and follow the repository-wide guidance in [`../AGENTS.md`](../AGENTS.md). It is the canonical source for project architecture, commands, conventions, test requirements, and workspace safety.

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 # Build directories
 build/
+build*/
 .cache/
 .vs/
 .vscode/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,96 @@
+# WebFront contributor and agent guide
+
+## Project goal and current maturity
+
+WebFront is a C++23 header-only library for serving a browser UI from a C++ application. It embeds an HTTP/WebSocket server and exposes a binary bridge for fire-and-forget calls in both directions:
+
+- JavaScript calls registered C++ callbacks with `webFront.cppFunction(name)`.
+- C++ calls browser functions with `ui.jsFunction(name)(arguments...)`.
+
+The project is an experimental foundation, not a production-ready UI framework. The minimum supported demonstration is the native ES-module example plus the automated Jasmine browser integration test. Function return values, remote exception propagation, and general DOM abstractions are future work.
+
+## Repository map
+
+- `include/`: public header-only library. `WebFront.hpp` is the main orchestration API.
+- `include/http/`: HTTP and WebSocket protocol implementation.
+- `include/weblink/`: bridge message encoding and routing.
+- `include/system/`: layered virtual filesystems and embedded web resources.
+- `include/frontend/`: system-browser and CEF frontend adapters.
+- `src/`: example applications and browser assets. `module-demo.html` is the minimal demo.
+- `test/`: Catch2 unit tests.
+- `webtest/`: Jasmine real-browser integration test.
+- `cmake/` and `.github/workflows/`: build support and CI.
+- `docs/PROJECT_STATUS.md`: evidence-based status snapshot and known limitations.
+- `docs/ISSUE_AUDIT.md`: recommendations for the current GitHub backlog.
+
+The legacy `webfront/`, `tests/`, and `webtest` directories are not interchangeable: use `test/` for current C++ tests and `webtest/` for browser tests. Do not revive legacy code without a specific issue and regression coverage.
+
+## Build and test commands
+
+Use out-of-source builds. CPM downloads dependencies during first configure, so network access may be required.
+
+```bash
+# Fast, portable C++ baseline (no CEF download)
+cmake -S . -B build -DCMAKE_BUILD_TYPE=Release \
+  -DWEBFRONT_EMBED_CEF=OFF -DENABLE_TESTING=ON
+cmake --build build --parallel
+ctest --test-dir build --output-on-failure
+
+# Run one Catch2 scenario directly
+./build/test/tests "Scenario: JsFunction"
+
+# Linux real-browser integration test
+cmake -S . -B build-cef -DCMAKE_BUILD_TYPE=Release \
+  -DWEBFRONT_EMBED_CEF=ON -DENABLE_TESTING=ON
+cmake --build build-cef --target webtest --parallel
+ctest --test-dir build-cef -L web-integration --output-on-failure
+
+# Manual native-module demo (CEF-off opens the system browser)
+./build/src/WebFrontApp
+
+# Optional React example
+./build/src/WebFrontApp react.html
+```
+
+Important CMake options:
+
+- `WEBFRONT_EMBED_CEF=OFF`: use the system browser; this is the normal unit-test build.
+- `WEBFRONT_EMBED_CEF=ON`: download/link CEF and enable the automated browser test.
+- `ENABLE_TESTING=ON`: build Catch2 and Jasmine test targets.
+- `ENABLE_COVERAGE=ON`: add GCC/Clang coverage instrumentation to the C++ tests.
+
+If the environment provides a read-only default ccache directory, set `CCACHE_DIR` to a writable temporary directory for local builds. Do not encode machine-specific cache paths in project files.
+
+## Architecture and invariants
+
+`BasicWF<NetProvider, Filesystem, Policy, Frontend>` owns the HTTP server, connected `WebLink` objects, registered C++ callbacks, and server thread. `BasicUI` identifies one connected browser. A frontend must satisfy `frontend::FrontendType` and decides whether the server stops when `open()` returns.
+
+Filesystems implement `open(std::filesystem::path) -> std::optional<fs::File>` and are composed with `fs::Multi<>`; the first provider returning a file wins. `NativeDebugFS` is development-only and must not be presented as a production sandbox.
+
+Bridge calls are asynchronous and fire-and-forget. Do not write tests or documentation that imply `cppFunction()` returns the C++ result to JavaScript, or that `JsFunction::operator()` returns a JavaScript value. Registered callback objects must outlive their registration through owned storage; never capture a forwarding-reference parameter by reference in a stored handler.
+
+The embedded `WebFront.js` wire format and C++ `Messages.hpp` implementation must evolve together. Any protocol change requires encoding/decoding unit tests and a real-browser regression test.
+
+## Coding and testing conventions
+
+- Use C++23, four-space indentation, the repository `.clang-format`, and the naming rules in `CONTRIBUTING.md`.
+- Keep production implementation header-only under `include/`; `src/` contains examples only.
+- Prefer standard-library facilities and explicit ownership. Keep public headers ODR-safe (`inline`/templates as appropriate).
+- Catch2 tests use `SCENARIO`/`GIVEN`/`WHEN`/`THEN` and deterministic mocks.
+- Jasmine tests use native modules and must report completion to C++, close themselves, return a meaningful process status, and have a CTest timeout.
+- Every bug fix needs a failing regression test at the lowest useful level. Bridge changes also need the browser integration test.
+- Tests must not require user input, a fixed pre-existing browser session, or public network access after dependencies are configured.
+
+Before declaring work complete, run the CEF-off build and CTest suite. Run the CEF/Xvfb test when changing the bridge, browser lifecycle, module serving, Jasmine assets, or CEF frontend. Update README/status documentation when commands, public behavior, or limitations change.
+
+## Git and workspace safety
+
+The workspace may contain user-owned untracked documents and large build directories. Never delete, move, format, stage, or overwrite unrelated files. In particular, names such as `A_faire*`, `Texte*`, calendar SVGs, `data/`, local batch files, and existing `build*` trees are not automatically project work.
+
+Inspect `git status --short` before and after changes. Preserve overlapping user edits and use targeted patches. Never use destructive reset/checkout commands. Feature branches follow the issue-number convention and target `develop`; `master` is the release branch. GitHub issue changes require explicit user authorization and evidence from code/tests/history.
+
+Commits and pull requests must never contain AI-assistance attribution. Do not add `Co-authored-by` trailers for an AI tool, generated-by notices, bot attribution, or statements crediting Codex, Claude, Copilot, Vibe, or another assistant in commit messages, commit trailers, PR titles, or PR descriptions.
+
+## Definition of done
+
+A change is done only when its intended behavior is demonstrated, relevant unit and integration tests pass, failure paths return nonzero or throw as documented, CI/build instructions match reality, public limitations are not overstated, and the final diff contains no unrelated workspace files.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,3 @@
+# Claude Code instructions
+
+Read and follow the repository-wide guidance in [`AGENTS.md`](AGENTS.md). It is the canonical source for project architecture, commands, conventions, test requirements, and workspace safety.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,3 +1,0 @@
-# Claude Code instructions
-
-Read and follow the repository-wide guidance in [`AGENTS.md`](AGENTS.md). It is the canonical source for project architecture, commands, conventions, test requirements, and workspace safety.

--- a/README.md
+++ b/README.md
@@ -1,90 +1,73 @@
 # WebFront
 
-A C++23 header-only library with the aim of providing rich cross-platform UI (Typescript based) to C++ applications with a non-invasive API.
+WebFront is an experimental C++23 header-only library for browser-based user interfaces. It serves local HTML/JavaScript through an embedded HTTP server and connects the page to C++ over WebSocket.
 
-WebFront implements the websocket protocol over an embedded Web server and provides CppToJs and JsToCpp cross functions calls with native types conversions.
+The current baseline demonstrates asynchronous, fire-and-forget calls in both directions:
 
-[![Windows MSVC](https://img.shields.io/endpoint?url=https://gist.githubusercontent.com/ambroise-leclerc/317c22bfe80b2b51663187fbebfba533/raw/windows-latest-msvc.json)](https://github.com/ambroise-leclerc/WebFront/actions/workflows/BuildAndTest.yml)
-[![Ubuntu GCC](https://img.shields.io/endpoint?url=https://gist.githubusercontent.com/ambroise-leclerc/317c22bfe80b2b51663187fbebfba533/raw/ubuntu-latest-gcc.json)](https://github.com/ambroise-leclerc/WebFront/actions/workflows/BuildAndTest.yml)
-[![Ubuntu Clang](https://img.shields.io/endpoint?url=https://gist.githubusercontent.com/ambroise-leclerc/317c22bfe80b2b51663187fbebfba533/raw/ubuntu-latest-clang.json)](https://github.com/ambroise-leclerc/WebFront/actions/workflows/BuildAndTest.yml)
-[![MacOS Clang](https://img.shields.io/endpoint?url=https://gist.githubusercontent.com/ambroise-leclerc/317c22bfe80b2b51663187fbebfba533/raw/macos-latest-clang.json)](https://github.com/ambroise-leclerc/WebFront/actions/workflows/BuildAndTest.yml)
-[![codecov](https://codecov.io/github/ambroise-leclerc/WebFront/branch/master/graph/badge.svg?token=ODE6O36XIV)](https://codecov.io/github/ambroise-leclerc/WebFront)
+- JavaScript obtains a registered callback with `webFront.cppFunction('name')` and calls C++.
+- C++ obtains a browser function with `ui.jsFunction("name")` and calls served JavaScript.
 
-[![CodeScene Code Health](https://codescene.io/projects/29377/status-badges/code-health)](https://codescene.io/projects/29377)
-[![CodeScene System Mastery](https://codescene.io/projects/29377/status-badges/system-mastery)](https://codescene.io/projects/29377)
+Function return values and remote exception propagation are not implemented yet.
 
-## Getting started
+## Build and test
 
-#### Hello World
-```cpp
-    WebFront webfront;
-    webFront.cppFunction<void, std::string>("print", [](std::string text) {
-        std::cout << text << '\n';
-    });
+The normal build avoids the large optional CEF dependency and runs the portable Catch2 suite:
 
-    webFront.onUIStarted([](UI ui) {
-        ui.addScript("var addText = function(text, num) {                 "
-                     "  let print = webFront.cppFunction('print');        "
-                     "  print(text + ' of ' + num);                       "
-                     "}                                                   ");
-        auto print = ui.jsFunction("addText");
-        print("Hello World", 2023);
-    });
-
+```bash
+cmake -S . -B build -DCMAKE_BUILD_TYPE=Release \
+  -DWEBFRONT_EMBED_CEF=OFF -DENABLE_TESTING=ON
+cmake --build build --parallel
+ctest --test-dir build --output-on-failure
 ```
 
-#### Choosing a frontend
-`webfront::WebFront` still uses the default frontend selected at build time. To force a specific frontend in user code, use `WebFrontWithFrontend` or `BasicWFWithFrontend`:
+Relevant options are:
+
+- `WEBFRONT_EMBED_CEF=OFF`: open examples in the system browser.
+- `WEBFRONT_EMBED_CEF=ON`: build the embedded Chromium frontend and browser integration test.
+- `ENABLE_TESTING=ON`: build Catch2 and Jasmine test targets.
+- `ENABLE_COVERAGE=ON`: instrument the C++ tests with GCC/Clang coverage flags.
+
+CPM downloads Networking TS during configuration. It also downloads Catch2 when `ENABLE_TESTING=ON` and CEF when
+`WEBFRONT_EMBED_CEF=ON`.
+
+## Minimal native-module demo
+
+Run the default example after a CEF-off build:
+
+```bash
+./build/src/WebFrontApp
+```
+
+The application serves `src/module-demo.html`, whose entry module imports the other `.mjs` files with relative URLs. After the WebSocket is ready, the module calls the registered C++ `moduleReady` callback; C++ then calls `webfrontModule.receiveFromCpp`, a function installed by the served module. The page button demonstrates the reverse JavaScript-to-C++ call.
+
+The older React/Babel example remains available explicitly:
+
+```bash
+./build/src/WebFrontApp react.html
+```
+
+When the system-browser frontend is used, press Enter in the application terminal after closing the page. A CEF-enabled build uses an embedded window and stops when that window closes.
+
+## Automated browser integration
+
+On Linux with Xvfb available:
+
+```bash
+cmake -S . -B build-cef -DCMAKE_BUILD_TYPE=Release \
+  -DWEBFRONT_EMBED_CEF=ON -DENABLE_TESTING=ON
+cmake --build build-cef --target webtest --parallel
+ctest --test-dir build-cef -L web-integration --output-on-failure
+```
+
+The Jasmine specs are native ES modules. They prove relative module loading and both bridge directions, report the final result to C++, close the CEF window automatically, and fail CTest on an assertion, bridge, startup, or timeout error.
+
+## Selecting a frontend
+
+`webfront::WebFront` uses the frontend selected by the build. Applications can select one explicitly:
 
 ```cpp
 using BrowserFront = webfront::WebFrontWithFrontend<webfront::frontend::DefaultBrowserFrontend>;
 using EmbeddedFront = webfront::WebFrontWithFrontend<webfront::frontend::CEFFrontend>;
 ```
 
-## Building and Testing
-
-### Build Configuration
-```bash
-# Configure build (Release by default)
-cmake . -B build
-
-# Configure with Debug and coverage  
-cmake . -B build -DCMAKE_BUILD_TYPE=Debug -DENABLE_COVERAGE=ON
-
-# Configure with embedded Windows (instead of ystem browser)
-cmake . -B build -DWEBFRONT_EMBED_CEF=ON
-
-# Build the project
-cmake --build build --config Release --parallel
-```
-
-#### CMake Options
-- `WEBFRONT_EMBED_CEF=OFF` (default): Disable CEF, applications will use the system browser instead
-- `WEBFRONT_EMBED_CEF=ON`: Enable embedded CEF window support for chromeless application windows
-- `ENABLE_TESTING=ON` (default): Build unit tests
-- `ENABLE_COVERAGE=ON`: Enable test coverage collection
-
-### Running Examples
-
-#### WebFrontApp - React Example with Embedded Window
-The main example application demonstrates React integration with TypeScript/Babel transpilation in a chromeless CEF window:
-
-```bash
-cd build
-./src/WebFrontApp
-```
-
-When built with `WEBFRONT_EMBED_CEF=ON`, this opens a clean chromeless application window. When built with `WEBFRONT_EMBED_CEF=OFF`, it opens in your system browser. The application provides:
-- **Unified API**: `webfront::WebFront` picks the default frontend, and `webfront::WebFrontWithFrontend<>` can force one explicitly
-- **Chromeless UI**: Clean application window without browser chrome elements (CEF only)
-- **React Support**: Full React 18 + JSX + Babel transpilation
-- **C++/JS Interop**: Bidirectional function calls between C++ and JavaScript
-- **TypeScript Ready**: Modern JavaScript features and type support
-
-#### webtest - Jasmine Test Runner with Embedded Window  
-Run the JavaScript test suite in an embedded CEF window for automated testing:
-
-```bash
-cd build
-./webtest/webtest
-```
+See [AGENTS.md](AGENTS.md) for architecture, development commands, conventions, test requirements, and safety guidance. The current evidence-based status and backlog recommendations are in [docs/PROJECT_STATUS.md](docs/PROJECT_STATUS.md) and [docs/ISSUE_AUDIT.md](docs/ISSUE_AUDIT.md).

--- a/docs/ISSUE_AUDIT.md
+++ b/docs/ISSUE_AUDIT.md
@@ -1,0 +1,32 @@
+# Open GitHub issue audit
+
+Audit snapshot: 2026-07-16. These are recommendations only; no GitHub issues were changed.
+
+| Issue | Finding | Recommended action |
+|---|---|---|
+| #189 Update develop branch | `develop` is the active integration branch, is ahead of `master`, and its latest matrix passed. The issue has no acceptance criteria. | Close as completed or obsolete with branch/CI evidence. |
+| #137 MSEdgeWebview2 frontend | Still a distinct possible frontend; a remote feature branch exists, but the parent frontend epic is closed. | Retain only after rewriting scope, supported Windows versions, lifecycle API, and tests; keep outside the minimal milestone. |
+| #133 CreateReactApp evaluation | Create React App is no longer an appropriate basis for new React integrations. | Close as obsolete. Create a Vite-specific evaluation only if Node integration becomes a current goal. |
+| #132 JavaScript modules | MIME support existed, but no automated module graph and bridge proof existed. | Close when the module demo and browser test in this milestone merge. |
+| #125 ReactFS integration | ReactFS, BabelFS, and the named child tasks are implemented; the remaining placeholder task is undefined. | Close as completed; file focused follow-ups for actual missing behavior. |
+| #120 Integrated WebFront UI | Broad product idea with no current acceptance criteria. | Rewrite as a concrete roadmap epic or close as inactive. |
+| #121 Status/debug overlay | Empty placeholder under #120. | Close unless rewritten with user-visible behavior and frontend constraints. |
+| #122 Developer overlay | Empty placeholder and overlaps #121. | Consolidate into a rewritten overlay issue or close. |
+| #123 Browser-backed download | Potentially useful but unrelated to the baseline and lacks security/lifetime semantics. | Retain only after defining API, storage ownership, permissions, and tests; otherwise close. |
+| #124 Conway readme application | Empty aspirational issue. | Close or rewrite as a documentation/demo task with assets and acceptance criteria. |
+| #114 Jasmine automation | Remains valid: Jasmine assets existed, but results were not connected to CTest/CI. | Close when the automated CEF/Xvfb test merges. |
+| #115 GruntJS evaluation | Superseded by direct Jasmine plus CEF/Xvfb; Grunt adds no necessary capability. | Close as superseded by #114 implementation. |
+| #116 Selenium evaluation | Unneeded for the selected minimal in-process browser path. | Close as superseded; create a new cross-browser issue only if required later. |
+| #117 Headless Chrome evaluation | Superseded for the minimal milestone by CEF under Xvfb. | Close as superseded, noting that Playwright may be reconsidered for future cross-browser coverage. |
+| #118 Chromatic evaluation | Visual-regression SaaS is unrelated to bridge correctness and the issue is empty. | Close as out of scope. |
+| #119 Jasmine Headless WebKit | Superseded by the selected CEF path and has no acceptance criteria. | Close as superseded. |
+| #35 Function return | Return/error propagation is not implemented despite partial message types. | Retain as the canonical epic; define correlation IDs, async result API, errors, timeouts, and compatibility. |
+| #43 JSReturnValue | Overlaps the C++-to-JS half of #35. | Consolidate into #35 and close as duplicate after preserving its future-like API considerations. |
+| #39 Arrays in calls | Enum values exist, but general/typed array encoding is incomplete. | Retain and rewrite with supported element types, ownership, size limits, round-trip tests, and both directions. |
+| #38 FileSystem | Layered native and virtual filesystems are implemented; archived packaging remains only an idea. | Close as completed. Open a separate packaged/archive filesystem issue if still wanted. |
+| #36 JS strings to views | Technically possible but exposes reception-buffer lifetime hazards. | Retain only as an explicit zero-copy API design task with lifetime guarantees; otherwise close as unsafe/not planned. |
+| #28 UI per browser document | `BasicUI` is created per connected `WebLink` and supports script/function interaction; DOM ambitions are undefined. | Close the implemented issue and create a separate DOM API epic only if still desired. |
+
+## Closed issue consistency note
+
+Issue #187 (“Add Jasmine C++/JS bridge testing to JasmineTest”) was closed even though its assertions required unsupported synchronous return values and the executable was not connected to CTest results. The new automation should be referenced in any closing comment for #114 so the historical distinction is clear.

--- a/docs/PROJECT_STATUS.md
+++ b/docs/PROJECT_STATUS.md
@@ -1,0 +1,41 @@
+# WebFront project status
+
+Status snapshot: 2026-07-16, branch `132-javascript-modules`, based on `develop` commit `4eac25f`.
+
+## Intended product
+
+WebFront is a C++23 header-only experiment for browser-based C++ user interfaces. A C++ process serves local HTML/JavaScript and exchanges typed function-call messages with the page over WebSocket. It supports an embedded CEF frontend or the system browser.
+
+The minimum demonstration milestone is deliberately narrower than the long-term vision: serve a native ES-module graph and automatically prove one JavaScript-to-C++ call and one C++-to-served-JavaScript call with Jasmine.
+
+## Verified baseline before this milestone
+
+- The current branch had no commits beyond `develop`; its issue-132 work existed only as local modified/untracked files.
+- A CEF-off `RelWithDebInfo` build completed successfully on Linux.
+- All 42 CTest-discovered Catch2 scenarios passed in 0.19 seconds.
+- The latest `develop` GitHub Actions run (2026-05-31) passed its Windows MSVC, Ubuntu GCC, Ubuntu Clang, and macOS AppleClang matrix.
+- The existing `webtest` executable was not registered with CTest. It opened a window, required manual closure, swallowed runtime errors, and could return success without evaluating Jasmine results.
+- Existing Jasmine specs expected JavaScript calls to receive a C++ return value. The runtime bridge is fire-and-forget: `BasicWF::cppFunction` ignored `R`, and embedded `WebFront.js` did not handle `functionReturn` messages. Those assertions therefore did not describe implemented behavior.
+- Registered C++ callables were captured through a forwarding-reference parameter, leaving stored callbacks with a dangling reference.
+- `.mjs` already mapped to `application/javascript`; issue #132 still lacked an end-to-end module/browser demonstration.
+- Documentation and CI used `ENABLE_COVERAGE`, while the test target checked `ENABLE_TEST_COVERAGE`, so requested coverage instrumentation was not enabled.
+
+## Implemented baseline
+
+- The default example is the native ES-module demo. Its module graph uses relative imports, calls C++, and exposes a served JavaScript function that C++ calls after module readiness.
+- Registered C++ callbacks own their callable safely. Calls remain asynchronous and return no value across the bridge.
+- Catch2 covers `.mjs` MIME handling.
+- Jasmine native-module specs report their final status to C++. The executable verifies both bridge directions, asks JavaScript to close the CEF window, and returns nonzero on any failed condition.
+- The browser integration is a timeout-bounded CTest test for CEF-enabled Linux builds and runs under Xvfb in a focused CI job.
+- `AGENTS.md` is the canonical development guide for supported coding agents.
+
+Local verification on 2026-07-16 completed successfully: the CEF-off build passed all 44 Catch2 scenarios, JavaScript module syntax checks passed, coverage flags appeared when `ENABLE_COVERAGE=ON`, and a fresh CEF-enabled build passed `WebFrontBrowserIntegration` under Xvfb. The verbose browser run showed both tokenized bridge calls, a `passed` Jasmine report, and automatic CEF shutdown.
+
+## Known limitations and next decisions
+
+- JavaScript/C++ function results and remote exceptions are not propagated. The existing `FunctionReturn` message type is protocol groundwork, not a working public feature.
+- Bridge lookup and connection errors need a defined cross-language error contract.
+- Arrays/typed arrays are incomplete; JavaScript arrays currently encode as tuple-like parameters.
+- `NativeDebugFS` exposes development files and is not a production packaging format.
+- CEF is a large optional dependency. Only the focused Linux integration job should download it for the minimal baseline.
+- React/Babel assets remain examples rather than the core demonstration. Modern Node/Vite integration, WebView2, overlays, and packaged filesystems require separate product decisions.


### PR DESCRIPTION
## Summary
- add canonical repository-wide contributor and agent guidance
- document the verified project baseline and known limitations
- record evidence-based recommendations for the open issue backlog
- update README commands and demonstration scope
- keep local build directories out of version control
- prohibit attribution trailers and generated-by notices in commits and pull requests

## Testing
- documentation commands were verified against the implemented stack
- branch diff and commit metadata were audited
- no unrelated workspace files are included

Depends on #197