### PR TITLE
Fix broken __cpp_lib_format workaround on Apple toolchains

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -31,9 +31,12 @@ include(StandardProjectSettings)
 include(PreventInSourceBuilds)
 add_library(WebFront_options INTERFACE)
 target_compile_features(WebFront_options INTERFACE cxx_std_23)
-if(APPLE)
-  target_compile_definitions(WebFront_options INTERFACE __cpp_lib_format=202207L)
-endif()
+# Do not force-define __cpp_lib_format on the command line: unlike a header setting it after
+# actually providing <format>, a command-line -D applies from the start of every translation
+# unit, so other standard headers (e.g. <vector>) that gate their own <format> integration on
+# this macro see it "on" before <format> has been included and fail to compile. Let each
+# toolchain's own <version>/<format> define it accurately; include/details/C++20Support.hpp
+# already falls back to a minimal std::format polyfill when a toolchain leaves it undefined.
 
 add_library(WebFront_warnings INTERFACE)
 


### PR DESCRIPTION
## Summary

- `CMakeLists.txt` force-defined `__cpp_lib_format` on the compiler command line for all Apple builds. A command-line `-D` applies from the very start of every translation unit, so standard headers that gate their own `<format>` integration on this macro (e.g. `<vector>`) see it "on" before `<format>` has actually been included, and fail to compile.
- It also masked that some Apple Clang libc++ builds only implement `std::format` and not `std::vformat`/`make_format_args`.
- Removing the forced define lets each toolchain's own `<version>`/`<format>` detection set it accurately; `include/details/C++20Support.hpp` already falls back to a minimal `std::format` polyfill when a toolchain leaves it undefined.

Discovered while verifying an unrelated change on a current macOS toolchain (Xcode 21 AppleClang and Homebrew GCC 15 both hit this); reproduces identically on unmodified `develop`.

## Test plan
- [x] Clean CEF-off configure + build succeeds
- [x] `ctest` — 56/56 existing Catch2 scenarios pass
