### PR TITLE
Make browser frontend selection explicit

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ The Jasmine specs are native ES modules. They prove relative module loading, bot
 
 ## Selecting a frontend
 
-`webfront::WebFront` uses the frontend selected by the build. Applications can select one explicitly:
+`webfront::WebFront` always opens the system browser, regardless of whether the build has CEF support (`WEBFRONT_EMBED_CEF`) enabled. Applications opt into the embedded CEF frontend explicitly:
 
 ```cpp
 using BrowserFront = webfront::WebFrontWithFrontend<webfront::frontend::DefaultBrowserFrontend>;

--- a/include/WebFront.hpp
+++ b/include/WebFront.hpp
@@ -191,6 +191,15 @@ public:
     }
 
     enum class WindowAction { none, closeWindow };
+#ifdef _MSC_VER
+    // A Frontend::open() that unconditionally throws (e.g. CEFFrontend::open() when CEF support
+    // isn't compiled in) makes the returns below provably unreachable for that instantiation, both
+    // here and in openAndRun() below it (which calls openWindow()). MSVC detects this via inlining
+    // and, uniquely among our compilers, flags it as an error under /WX; it's expected, not a bug,
+    // so it's suppressed narrowly rather than relaxed project-wide.
+    #pragma warning(push)
+    #pragma warning(disable : 4702)
+#endif
     WindowAction openWindow(std::string_view htmlFilename) {
         Frontend::open(httpPort, htmlFilename);
         if constexpr (Frontend::action == frontend::Action::closeServerAfterOpen)
@@ -215,6 +224,9 @@ public:
                 serverThread.join();
         }
     }
+#ifdef _MSC_VER
+    #pragma warning(pop)
+#endif
 
 private:
     http::Server<Net, Filesystem, Policy>                                    httpServer;

--- a/include/frontend/CEF.hpp
+++ b/include/frontend/CEF.hpp
@@ -17,6 +17,7 @@
     #include <fstream>
 #elif __APPLE__
     #include <crt_externs.h>
+    #include <mach-o/dyld.h>
 #endif
 
 namespace webfront::cef {
@@ -73,7 +74,6 @@ constexpr const char* kICUDataFile         = "icudtl.dat";
 constexpr const char* kLocalesDir          = "locales";
 constexpr const char* kFrameworkName       = "Chromium Embedded Framework.framework";
 constexpr const char* kResourcesDir        = "Resources";
-constexpr const char* kExecutableName      = "WebFrontApp";
 }  // namespace
 
 // Helper function to set keychain-related environment variables
@@ -87,14 +87,29 @@ inline void setKeychainEnvironment() {
     #endif
 }
 
+#ifdef __APPLE__
+// Resolves the actual running executable's path, independent of its target name or working
+// directory. CEF needs this for the browser subprocess and to locate its sibling Frameworks/
+// Resources directories, which CMake copies next to whichever target is running (WebFrontApp,
+// webtest, or any other CEF-enabled example), not into a fixed "src/" layout.
+inline std::filesystem::path currentExecutablePath() {
+    uint32_t size = 0;
+    _NSGetExecutablePath(nullptr, &size);
+    std::string buffer(size, '\0');
+    if (_NSGetExecutablePath(buffer.data(), &size) != 0)
+        throw CEFInitializationError("Unable to resolve the current executable path");
+    return std::filesystem::canonical(buffer);
+}
+#endif
+
 // Helper function to configure platform-specific paths
 inline void configurePlatformPaths(CefSettings& settings [[maybe_unused]]) {
     #ifdef __APPLE__
     // Set framework and resource paths for macOS
-    std::filesystem::path exe_dir        = std::filesystem::current_path();
+    std::filesystem::path exe_path       = currentExecutablePath();
+    std::filesystem::path exe_dir        = exe_path.parent_path();
     std::filesystem::path framework_path = exe_dir / "Frameworks" / kFrameworkName;
     std::filesystem::path resources_path = framework_path / kResourcesDir;
-    std::filesystem::path exe_path       = exe_dir / "src" / kExecutableName;
     std::filesystem::path cache_path     = exe_dir / kCEFCacheDir;
     std::filesystem::create_directories(cache_path);
 
@@ -443,13 +458,19 @@ namespace webfront::cef {
 // Compile-time constant indicating CEF availability
 static constexpr bool webfrontEmbedCEF{false};
 
-// Stub implementations for when CEF is not available
+// Stub implementations for when CEF is not available. Selecting CEFFrontend without CEF support
+// must fail clearly and as early as possible (initialize() runs once at BasicWF construction,
+// before open() would otherwise be reached from openAndRun()).
 inline void initialize() {
-    // No-op when CEF is not available
+    throw std::runtime_error(
+      "webfront::frontend::CEFFrontend requires CEF support, but this build was configured with "
+      "WEBFRONT_EMBED_CEF=OFF. Reconfigure with -DWEBFRONT_EMBED_CEF=ON to use the embedded CEF frontend.");
 }
 
 inline void open(std::string_view /*port*/, std::string_view /*file*/) {
-    throw std::runtime_error("cef::open() : CEF not available");
+    throw std::runtime_error(
+      "webfront::frontend::CEFFrontend requires CEF support, but this build was configured with "
+      "WEBFRONT_EMBED_CEF=OFF. Reconfigure with -DWEBFRONT_EMBED_CEF=ON to use the embedded CEF frontend.");
 }
 
 }  // namespace webfront::cef

--- a/include/frontend/Frontend.hpp
+++ b/include/frontend/Frontend.hpp
@@ -50,6 +50,8 @@ struct CEFFrontend {
     }
 };
 
-using DefaultFrontend = std::conditional_t<cef::webfrontEmbedCEF, CEFFrontend, DefaultBrowserFrontend>;
+// WEBFRONT_EMBED_CEF only means "CEF is available"; it never changes which frontend
+// plain WebFront selects. Applications opt into CEF explicitly via WebFrontWithFrontend<CEFFrontend>.
+using DefaultFrontend = DefaultBrowserFrontend;
 
 }  // namespace webfront::frontend

--- a/test/WebFrontTests.cpp
+++ b/test/WebFrontTests.cpp
@@ -125,16 +125,26 @@ struct ClosingFrontend {
 }  // namespace
 
 SCENARIO("Frontend selection aliases") {
-    THEN("the default frontend follows the CEF availability") {
-        if constexpr (cef::webfrontEmbedCEF)
-            REQUIRE(std::is_same_v<frontend::DefaultFrontend, frontend::CEFFrontend>);
-        else
-            REQUIRE(std::is_same_v<frontend::DefaultFrontend, frontend::DefaultBrowserFrontend>);
+    THEN("the default frontend is always the system browser, regardless of CEF availability") {
+        REQUIRE(std::is_same_v<frontend::DefaultFrontend, frontend::DefaultBrowserFrontend>);
     }
 
     THEN("the convenience alias keeps the selected frontend type") {
         using FrontendWF = BasicWFWithFrontend<WebFrontNetworkingMock, TestFilesystem, OpeningFrontend>;
         REQUIRE(std::is_same_v<typename FrontendWF::FrontendProvider, OpeningFrontend>);
+    }
+}
+
+SCENARIO("Selecting CEFFrontend without CEF support fails clearly") {
+    GIVEN("a build without CEF support") {
+        WHEN("a CEF-fronted WebFront is constructed") {
+            THEN("construction throws a clear diagnostic instead of silently doing nothing") {
+                if constexpr (!cef::webfrontEmbedCEF) {
+                    using CEFWF = BasicWFWithFrontend<WebFrontNetworkingMock, TestFilesystem, frontend::CEFFrontend>;
+                    REQUIRE_THROWS_AS(CEFWF("9200"), std::runtime_error);
+                }
+            }
+        }
     }
 }
 

--- a/webtest/JasmineTest.cpp
+++ b/webtest/JasmineTest.cpp
@@ -50,11 +50,22 @@ public:
         registerCallbacks();
     }
 
+#ifdef _MSC_VER
+    // openAndRun() never returns normally here: TestWF selects CEFFrontend explicitly, and its
+    // open() unconditionally throws in a CEF-off build (this is intentional - see #206). MSVC's
+    // inliner detects that and flags the return below as unreachable, uniquely among our compilers,
+    // turning it into an error under /WX; see the matching suppression in include/WebFront.hpp.
+    #pragma warning(push)
+    #pragma warning(disable : 4702)
+#endif
     int run() {
         log::info("Starting automated Jasmine browser integration test");
         webFront.openAndRun("SpecRunner.html");
         return result();
     }
+#ifdef _MSC_VER
+    #pragma warning(pop)
+#endif
 
 private:
     TestWF               webFront;

--- a/webtest/JasmineTest.cpp
+++ b/webtest/JasmineTest.cpp
@@ -40,7 +40,9 @@ struct TestState {
 };
 
 using TestFS = fs::Multi<fs::NativeDebugFS, fs::IndexFS, fs::JasmineFS>;
-using TestWF = BasicWF<NetProvider, TestFS>;
+// The browser integration test needs an embedded, auto-closing window under Xvfb, so it selects
+// CEFFrontend explicitly rather than relying on webfront::WebFront's default (system) frontend.
+using TestWF = BasicWFWithFrontend<NetProvider, TestFS, frontend::CEFFrontend>;
 
 class BrowserIntegrationTest {
 public:


### PR DESCRIPTION
## Summary

- `DefaultFrontend` previously resolved to `CEFFrontend` automatically whenever `WEBFRONT_EMBED_CEF` was on, so a CEF-enabled build silently changed what plain `webfront::WebFront` did. `WEBFRONT_EMBED_CEF` now only means "CEF is available"; it never changes which frontend is selected. Applications opt into the embedded CEF frontend explicitly via `WebFrontWithFrontend<CEFFrontend>`.
- Selecting `CEFFrontend` without CEF support now throws a clear diagnostic immediately at construction, instead of silently no-op'ing until a later `openWindow()` call.
- Fixed CEF's macOS executable-path discovery, which was hardcoded to `src/WebFrontApp` and would break for any other CEF-enabled target (e.g. `webtest`, or a future example). It now resolves the actual running executable via `_NSGetExecutablePath`.
- `webtest` now explicitly selects `CEFFrontend` (previously relied on the old auto-switch behavior to get an embedded, auto-closing window under Xvfb in CI).
- Updated the one README sentence this makes inaccurate; the fuller documentation rewrite is a separate, later story in the same epic.

Closes #206. Part of epic #205.

## Test plan
- [x] CEF-off build + full Catch2 suite (57/57, including two new/updated scenarios)
- [x] CEF-enabled configure + build succeeds; confirmed the macOS executable-path fix runs successfully before CEF's own initialization
- [x] `webtest` (which now selects CEFFrontend explicitly) still builds against real CEF
