### PR TITLE
Fix WebSocket frame coalescing and shutdown race (#219)

### DIFF
--- a/include/http/WebSocket.hpp
+++ b/include/http/WebSocket.hpp
@@ -8,6 +8,7 @@
 #include "../tooling/Logger.hpp"
 
 #include <array>
+#include <atomic>
 #include <cstddef>
 #include <deque>
 #include <functional>
@@ -181,12 +182,15 @@ public:
 public:
     FrameDecoder() : payloadBuffer(sizeof(Header)) { reset(); }
     std::span<const std::byte> payload() const { return std::span(payloadBuffer.data(), payloadSize); }
+    [[nodiscard]] size_t consumed() const { return consumedSize; }
 
     // Parses some incoming data and tries to decode it.
     // @return true if the frame is complete, false if it needs more data
     bool parse(std::span<const std::byte> buffer) {
+        consumedSize = 0;
         auto decodePayload = [&](std::span<const std::byte> encoded) -> size_t {
             for (auto in : encoded) payloadBuffer.push_back(in ^ mask[maskIndex++ % 4]);
+            consumedSize += encoded.size();
             return payloadBuffer.size();
         };
         auto decodeHeader = [&](auto input) {
@@ -209,16 +213,18 @@ public:
             if (reinterpret_cast<const Header*>(buffer.data())->isComplete(buffer.size())) {
                 reinterpret_cast<const Header*>(buffer.data())->dump();
                 decodeHeader(buffer.data());
+                consumedSize = headerSize;
                 if (decodePayload(buffer.subspan(headerSize, std::min(buffer.size() - headerSize, payloadSize))) == payloadSize) return true;
                 state = DecodingState::decodingPayload;
             }
             else {
-                bufferizeHeaderData(buffer);
+                consumedSize = bufferizeHeaderData(buffer);
                 state = DecodingState::partialHeader;
             }
             break;
         case DecodingState::partialHeader: {
             auto consumedData = bufferizeHeaderData(buffer);
+            consumedSize = consumedData;
             if (headerBuffer.isComplete(headerBufferParser)) {
                 decodeHeader(headerBuffer.raw.data());
                 if (decodePayload(buffer.subspan(consumedData, std::min(buffer.size() - consumedData, payloadSize))) == payloadSize) return true;
@@ -226,8 +232,9 @@ public:
             }
         } break;
         case DecodingState::decodingPayload: {
-            decodePayload(buffer.first(std::min(payloadSize - payloadBuffer.size(), buffer.size())));
-            return (buffer.size() >= (payloadSize - payloadBuffer.size()));
+            const auto remaining = payloadSize - payloadBuffer.size();
+            decodePayload(buffer.first(std::min(remaining, buffer.size())));
+            return consumedSize == remaining;
         }
         }
         return false;
@@ -238,6 +245,7 @@ public:
         headerBufferParser = 0;
         payloadBuffer.clear();
         state = DecodingState::starting;
+        consumedSize = 0;
     }
 
 private:
@@ -246,6 +254,7 @@ private:
     Header headerBuffer;
     size_t headerBufferParser;
     size_t payloadSize, headerSize;
+    size_t consumedSize;
     std::array<std::byte, 4> mask;
     uint8_t maskIndex;
 };
@@ -274,8 +283,8 @@ public:
     }
 
     void stop() {
-        started = false;
-        socket.close();
+        if (started.exchange(false))
+            socket.close();
     }
 
     void onMessage(std::function<void(std::string_view)>&& handler) { textHandler = std::move(handler); }
@@ -298,7 +307,7 @@ private:
     std::function<void(std::span<const std::byte>)> binaryHandler;
     std::function<void(CloseEvent)> closeHandler;
     std::shared_ptr<WriteState> writeState{std::make_shared<WriteState>()};
-    bool started;
+    std::atomic_bool started;
 
 private:
     explicit WebSocket(typename Net::Socket netSocket) : socket(std::move(netSocket)), started(false) {
@@ -309,7 +318,13 @@ private:
         auto self(this->shared_from_this());
         socket.async_read_some(Net::Buffer(readBuffer), [this, self](std::error_code ec, std::size_t bytesTransferred) {
             if (!ec) {
-                if (decoder.parse(std::span(readBuffer.data(), bytesTransferred))) {
+                auto received = std::span(readBuffer.data(), bytesTransferred);
+                while (!received.empty() && started) {
+                    const auto frameComplete = decoder.parse(received);
+                    received = received.subspan(decoder.consumed());
+                    if (!frameComplete)
+                        break;
+
                     auto data = decoder.payload();
                     switch (decoder.frameType) {
                     case Header::Opcode::text:
@@ -326,12 +341,14 @@ private:
                     };
                     decoder.reset();
                 }
-                read();
+                if (started)
+                    read();
             }
-            else {
-                log::error("Error in websocket::read() : {}:{}", ec.value(), ec.message());
+            else if (started.exchange(false)) {
+                if (ec != Net::Error::OperationAborted)
+                    log::error("Error in websocket::read() : {}:{}", ec.value(), ec.message());
                 if (closeHandler) closeHandler(CloseEvent{static_cast<uint16_t>(ec.value()), ec.message()});
-                stop();
+                socket.close();
             }
         });
     }
@@ -364,10 +381,10 @@ private:
                 hasNext = !writeState->queue.empty();
             }
             if (ec) {
-                if (started) {
+                if (started.exchange(false)) {
                     log::error("Error during write : ec.value() = {}", ec.value());
                     if (closeHandler) closeHandler(CloseEvent{static_cast<uint16_t>(ec.value()), ec.message()});
-                    if (ec != Net::Error::OperationAborted) stop();
+                    socket.close();
                 }
             }
             else if (hasNext) writeNext();

--- a/test/WebLinkTests.cpp
+++ b/test/WebLinkTests.cpp
@@ -272,3 +272,37 @@ SCENARIO("WebLink dispatches browser messages and allocates distinct calls") {
         }
     }
 }
+
+SCENARIO("WebLink dispatches every WebSocket frame coalesced in one read") {
+    InjectableSocket::reset();
+    vector<WebLinkEvent::Code>    events;
+    string                        calledName;
+    WebLink<InjectableNetworking> link{InjectableSocket{}, 10, [&](WebLinkEvent event) {
+                                           events.push_back(event.code);
+                                           if (event.code == WebLinkEvent::Code::cppFunctionCalled)
+                                               calledName = event.text;
+                                       }};
+
+    GIVEN("A handshake and function call delivered together") {
+        msg::Handshake handshake;
+        const auto     handshakePayload = span(reinterpret_cast<const byte*>(handshake.header().data()), handshake.header().size());
+        auto           received         = clientFrame(handshakePayload);
+
+        msg::FunctionCall<>                    call;
+        websocket::Frame<InjectableNetworking> frame{span(reinterpret_cast<const byte*>(call.header().data()), call.header().size())};
+        const string                           functionName{"registered"};
+        call.encodeParameter(functionName, frame);
+        frame.freeze();
+        const auto callFrame = clientFrame(messagePayload(frame));
+        received.insert(received.end(), callFrame.begin(), callFrame.end());
+
+        WHEN("The socket completes one read") {
+            InjectableSocket::receive(received);
+
+            THEN("Both frames are dispatched in order") {
+                REQUIRE(events == vector{WebLinkEvent::Code::linked, WebLinkEvent::Code::cppFunctionCalled});
+                REQUIRE(calledName == "registered");
+            }
+        }
+    }
+}

--- a/test/WebSocketTests.cpp
+++ b/test/WebSocketTests.cpp
@@ -160,3 +160,78 @@ SCENARIO("WebSocket decoder") {
         }
     }
 }
+
+SCENARIO("WebSocket decoder preserves coalesced frames") {
+    GIVEN("Two masked text frames received in one chunk") {
+        const array<uint8_t, 16> frames{0x81,
+                                        0x82,
+                                        0x10,
+                                        0x11,
+                                        0x12,
+                                        0x13,
+                                        uint8_t{'o' ^ 0x10},
+                                        uint8_t{'n' ^ 0x11},
+                                        0x81,
+                                        0x82,
+                                        0x20,
+                                        0x21,
+                                        0x22,
+                                        0x23,
+                                        uint8_t{'o' ^ 0x20},
+                                        uint8_t{'k' ^ 0x21}};
+        const auto               bytes = std::span(reinterpret_cast<const std::byte*>(frames.data()), frames.size());
+        websocket::FrameDecoder  decoder;
+
+        WHEN("The first frame is decoded") {
+            REQUIRE(decoder.parse(bytes));
+            REQUIRE(decoder.consumed() == 8);
+            REQUIRE(decoder.payload().size() == 2);
+            REQUIRE(std::to_integer<char>(decoder.payload()[0]) == 'o');
+            REQUIRE(std::to_integer<char>(decoder.payload()[1]) == 'n');
+
+            THEN("The unconsumed bytes decode as the second frame") {
+                const auto firstFrameSize = decoder.consumed();
+                decoder.reset();
+                REQUIRE(decoder.parse(bytes.subspan(firstFrameSize)));
+                REQUIRE(decoder.consumed() == 8);
+                REQUIRE(decoder.payload().size() == 2);
+                REQUIRE(std::to_integer<char>(decoder.payload()[0]) == 'o');
+                REQUIRE(std::to_integer<char>(decoder.payload()[1]) == 'k');
+            }
+        }
+    }
+}
+
+SCENARIO("WebSocket decoder waits for an entire split payload") {
+    GIVEN("A masked text frame split across three reads") {
+        const array<uint8_t, 14> frame{0x81,
+                                       0x88,
+                                       0x10,
+                                       0x11,
+                                       0x12,
+                                       0x13,
+                                       uint8_t{'H' ^ 0x10},
+                                       uint8_t{'e' ^ 0x11},
+                                       uint8_t{'l' ^ 0x12},
+                                       uint8_t{'l' ^ 0x13},
+                                       uint8_t{'o' ^ 0x10},
+                                       uint8_t{' ' ^ 0x11},
+                                       uint8_t{'W' ^ 0x12},
+                                       uint8_t{'S' ^ 0x13}};
+        const auto               bytes = std::span(reinterpret_cast<const std::byte*>(frame.data()), frame.size());
+        websocket::FrameDecoder  decoder;
+
+        WHEN("The middle read still leaves payload bytes outstanding") {
+            REQUIRE_FALSE(decoder.parse(bytes.first(7)));
+            REQUIRE(decoder.consumed() == 7);
+            REQUIRE_FALSE(decoder.parse(bytes.subspan(7, 3)));
+            REQUIRE(decoder.consumed() == 3);
+
+            THEN("Only the final read completes the frame") {
+                REQUIRE(decoder.parse(bytes.subspan(10)));
+                REQUIRE(decoder.consumed() == 4);
+                REQUIRE(decoder.payload().size() == 8);
+            }
+        }
+    }
+}

--- a/test/WebSocketTests.cpp
+++ b/test/WebSocketTests.cpp
@@ -4,10 +4,70 @@
 #include <catch2/catch_test_macros.hpp>
 
 #include <array>
+#include <functional>
+#include <system_error>
+#include <vector>
 
 using namespace webfront;
 using namespace std;
 using Net = networking::NetworkingMock;
+
+namespace {
+
+// Lets a test control exactly when a pending async_read_some completes, and with what error -
+// needed to simulate a read finishing after the WebSocket has already been stopped.
+class InjectableSocket : public networking::SocketBaseMock {
+public:
+    void async_read_some(auto buffer, auto completion) {
+        readBuffer  = buffer;
+        readHandler = std::move(completion);
+    }
+
+    size_t write_some(auto input, error_code&) {
+        const auto* first = static_cast<const byte*>(input.data());
+        written.insert(written.end(), first, first + input.size());
+        return input.size();
+    }
+
+    void close() { closeCalls++; }
+    void shutdown(int) {}
+
+    static void fail(error_code error) {
+        REQUIRE(readHandler);
+        auto handler = std::move(readHandler);
+        handler(error, 0);
+    }
+
+    static void reset() {
+        readHandler = {};
+        written.clear();
+        closeCalls = 0;
+    }
+
+    static int closeCallCount() { return closeCalls; }
+
+private:
+    inline static networking::buffers::MutableBuffer readBuffer;
+    inline static function<void(error_code, size_t)>  readHandler;
+    inline static vector<byte>                        written;
+    inline static int                                 closeCalls = 0;
+};
+
+class InjectableNetworking : public networking::NetworkingMock {
+public:
+    using Socket = InjectableSocket;
+
+    template <typename WriteHandler>
+    static void AsyncWrite(Socket socket, auto buffers, WriteHandler handler) {
+        error_code error;
+        size_t     transferred = 0;
+        for (const auto& buffer : buffers)
+            transferred += socket.write_some(buffer, error);
+        handler(error, transferred);
+    }
+};
+
+} // namespace
 
 SCENARIO("WebSocket Headers decoding") {
     GIVEN("Some Header data") {
@@ -221,16 +281,63 @@ SCENARIO("WebSocket decoder waits for an entire split payload") {
         const auto               bytes = std::span(reinterpret_cast<const std::byte*>(frame.data()), frame.size());
         websocket::FrameDecoder  decoder;
 
+        // The middle chunk (6 bytes) delivers more than half but not all of the 7 outstanding
+        // payload bytes. A naive "recompute remaining after appending" check (remaining=7-1=6
+        // before this call, buffer.size()=6, but comparing against remaining *after* appending -
+        // 8-(1+6)=1 - would wrongly see 6 >= 1 and report the frame complete one byte early. This
+        // split is chosen specifically to fail under that bug; smaller middle chunks (e.g. 3 of 7)
+        // don't exercise it, since old and new logic coincidentally agree there.
         WHEN("The middle read still leaves payload bytes outstanding") {
             REQUIRE_FALSE(decoder.parse(bytes.first(7)));
             REQUIRE(decoder.consumed() == 7);
-            REQUIRE_FALSE(decoder.parse(bytes.subspan(7, 3)));
-            REQUIRE(decoder.consumed() == 3);
+            REQUIRE_FALSE(decoder.parse(bytes.subspan(7, 6)));
+            REQUIRE(decoder.consumed() == 6);
 
             THEN("Only the final read completes the frame") {
-                REQUIRE(decoder.parse(bytes.subspan(10)));
-                REQUIRE(decoder.consumed() == 4);
+                REQUIRE(decoder.parse(bytes.subspan(13)));
+                REQUIRE(decoder.consumed() == 1);
                 REQUIRE(decoder.payload().size() == 8);
+            }
+        }
+    }
+}
+
+SCENARIO("WebSocket stop() is idempotent") {
+    InjectableSocket::reset();
+    int  closeHandlerCalls = 0;
+    auto ws = websocket::WebSocket<InjectableNetworking>::create(InjectableSocket{});
+    ws->onClose([&closeHandlerCalls](websocket::CloseEvent) { ++closeHandlerCalls; });
+
+    GIVEN("a started WebSocket that is stopped explicitly while a read is pending") {
+        ws->start();
+        ws->stop();
+
+        WHEN("the still-pending read then completes with an error") {
+            InjectableSocket::fail(make_error_code(errc::bad_file_descriptor));
+
+            THEN("the error is treated as harmless: no duplicate close handler call or socket close") {
+                REQUIRE(closeHandlerCalls == 0);
+                REQUIRE(InjectableSocket::closeCallCount() == 1);
+            }
+        }
+
+        WHEN("stop() is called again") {
+            THEN("the second call does not close the socket a second time") {
+                REQUIRE_NOTHROW(ws->stop());
+                REQUIRE(InjectableSocket::closeCallCount() == 1);
+            }
+        }
+    }
+
+    GIVEN("a started WebSocket whose pending read fails with no prior explicit stop") {
+        ws->start();
+
+        WHEN("the read completes with an error") {
+            InjectableSocket::fail(make_error_code(errc::bad_file_descriptor));
+
+            THEN("the close handler fires exactly once and the socket is closed exactly once") {
+                REQUIRE(closeHandlerCalls == 1);
+                REQUIRE(InjectableSocket::closeCallCount() == 1);
             }
         }
     }


### PR DESCRIPTION
  Root cause: a TCP read containing multiple WebSocket frames only dispatched the first frame and silently discarded the
  remainder. Split payloads could also be marked complete prematurely.

  Changes:

  - Process every frame contained in a socket read and preserve partial frames in include/http/WebSocket.hpp:185.
  - Make shutdown idempotent and stop scheduling reads after closure, eliminating expected Bad file descriptor errors.
  - Added decoder regressions in test/WebSocketTests.cpp:164.
  - Added an end-to-end coalesced handshake/function-call regression in test/WebLinkTests.cpp:276.

  Validation:

  - CEF-off Release build succeeded.
  - CTest: 66/66 passed.
  - git diff --check passed.
  - CEF/Xvfb integration was not run because this is a Windows host.